### PR TITLE
Video tab: "Generate all" button to queue every scene's clip in sequence

### DIFF
--- a/calliope-web/src/lib/components/QueueStage.svelte
+++ b/calliope-web/src/lib/components/QueueStage.svelte
@@ -136,6 +136,61 @@
 		onError: (err) => toast.error(err instanceof Error ? err.message : String(err)),
 	});
 
+	// --- Batch generate: queue clips one by one, in timeline order. ---
+	// One POST per scene (the H3 prompt rewrite runs synchronously inside each
+	// request, so a single all-scenes POST could take minutes and time out).
+	// The queue worker then renders them strictly in sequence (concurrency 1).
+	let batching = $state(false);
+	let batchNote = $state('');
+
+	const scenesNeedingClip = $derived(
+		scenes.filter((s) => !['done', 'pending', 'running'].includes(statusOf(s))),
+	);
+	const batchTargets = $derived(
+		scenesNeedingClip.length > 0
+			? scenesNeedingClip
+			: scenes.filter((s) => !['pending', 'running'].includes(statusOf(s))),
+	);
+	const batchLabel = $derived(
+		batching
+			? batchNote
+			: scenesNeedingClip.length > 0
+				? `Generate all (${scenesNeedingClip.length})`
+				: 'Regenerate all',
+	);
+
+	async function generateAll() {
+		if (batching || batchTargets.length === 0) return;
+		batching = true;
+		let queued = 0;
+		const targets = [...batchTargets].sort((a, b) => a.order_index - b.order_index);
+		for (let i = 0; i < targets.length; i++) {
+			const scene = targets[i];
+			batchNote = `Queueing ${i + 1}/${targets.length}…`;
+			try {
+				// Resolve like the per-scene button does: session pick → scene's stored
+				// workflow → first enabled video workflow. A scene whose stored workflow
+				// was deleted would otherwise enqueue a job doomed to "No workflow found".
+				await jobsApi.generateVideos(projectId, {
+					scene_ids: [scene.id],
+					workflow_id: workflowFor(scene)?.id,
+				});
+				queued++;
+				client.invalidateQueries({ queryKey: ['jobs'] });
+				client.invalidateQueries({ queryKey: ['scenes'] });
+			} catch (err) {
+				toast.error(
+					`Scene #${scene.order_index}: ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
+		}
+		batching = false;
+		batchNote = '';
+		if (queued > 0) toast.success(`${queued} clip${queued === 1 ? '' : 's'} queued — rendering in sequence`);
+		await client.invalidateQueries({ queryKey: ['jobs'] });
+		await client.invalidateQueries({ queryKey: ['scenes'] });
+	}
+
 	function workflowFor(scene: Scene): Workflow | undefined {
 		const id = selectedWorkflow[scene.id] ?? scene.workflow_id ?? undefined;
 		return enabledWorkflows.find((w) => w.id === id) ?? enabledWorkflows[0] ?? undefined;
@@ -345,6 +400,17 @@
 		</p>
 	</div>
 	<div class="actions">
+		{#if scenes.length > 0}
+			<Button
+				variant="primary"
+				disabled={batching || batchTargets.length === 0}
+				loading={batching}
+				title="Queue every scene's clip in timeline order; the worker renders them one at a time"
+				onclick={generateAll}
+			>
+				<Icon name="film" size={14} /> {batchLabel}
+			</Button>
+		{/if}
 		<Button variant="secondary" onclick={togglePause}>
 			{$queueStatusQuery.data?.paused ? 'Resume queue' : 'Pause queue'}
 		</Button>


### PR DESCRIPTION
Adds a one-click way to render a whole timeline. On a 17-scene project, clicking Generate
per scene means babysitting the queue for an hour; this button queues everything and lets the
existing worker render clips one at a time.

Design notes:

- **One POST per scene, sequentially, in timeline order** — deliberately not a single
  all-scenes request: the H3 prompt rewrite runs synchronously inside each `generate-videos`
  request (1–3 min per scene on local models), so one bulk request for a long timeline would
  sit for many minutes and risk a fetch timeout. During the loop the button shows
  "Queueing i/n…"; a scene that fails to queue toasts and the loop continues.
- **State-aware label**: "Generate all (n)" targets only scenes without a clip (skipping done
  and in-flight scenes); it flips to "Regenerate all" when every scene has a clip.
- **Workflow resolution matches the per-scene button** (session pick → scene's stored
  workflow → first enabled video workflow). This also heals scenes whose stored workflow was
  deleted — without the fallback they enqueue a job doomed to "No workflow found for job"
  (see the companion issue).

Tested live against a real ComfyUI backend: queued scenes rendered strictly in sequence, the
label transitions behave, and failures surface per-scene without aborting the batch.

The workflow-resolution fallback in this PR also works around #12 client-side (stale `scenes.workflow_id` after a workflow delete).
