### PR TITLE
Script tab: per-scene "Chain from prev clip" toggle — start a clip from the previous scene's last frame

### DIFF
--- a/calliope-backend/src/calliope/agent/video_agent.py
+++ b/calliope-backend/src/calliope/agent/video_agent.py
@@ -197,12 +197,21 @@ async def enqueue_video_jobs(
                     location_image=loc_image,
                     extra=input_values_override,
                 )
+            payload: dict[str, Any] = {"input_values": values, "prompt": prompt}
+            if scene.get("chain_from_prev"):
+                # Resolved at RUN time by the worker (the previous scene's clip may not
+                # exist yet at enqueue time — e.g. a batch queues all scenes up front).
+                payload["chain_from_prev"] = True
+                payload["scene_order_index"] = scene.get("order_index")
+                # The value the location/first-image ref slot holds right now, so the
+                # worker can find and replace that exact slot whatever the layout.
+                payload["chain_replace_value"] = loc_image
             job = queue_manager.enqueue(
                 project_id=project_id,
                 kind="video",
                 workflow_id=workflow["id"] if workflow else None,
                 scene_id=scene["id"],
-                payload={"input_values": values, "prompt": prompt},
+                payload=payload,
             )
             if workflow and not scene.get("workflow_id"):
                 conn.execute(

--- a/calliope-backend/src/calliope/db.py
+++ b/calliope-backend/src/calliope/db.py
@@ -143,6 +143,10 @@ async def migrate_db(db_path: Path) -> None:
         conn.execute("ALTER TABLE scenes ADD COLUMN location_id INTEGER")
     if "video_path" not in scene_cols:
         conn.execute("ALTER TABLE scenes ADD COLUMN video_path TEXT")
+    if "chain_from_prev" not in scene_cols:
+        conn.execute(
+            "ALTER TABLE scenes ADD COLUMN chain_from_prev INTEGER NOT NULL DEFAULT 0"
+        )
     project_cols = {r[1] for r in conn.execute("PRAGMA table_info(projects)").fetchall()}
     if "cover_path" not in project_cols:
         conn.execute("ALTER TABLE projects ADD COLUMN cover_path TEXT")

--- a/calliope-backend/src/calliope/models/schemas.py
+++ b/calliope-backend/src/calliope/models/schemas.py
@@ -128,6 +128,7 @@ class SceneUpdate(BaseModel):
     character_ids: list[int] | None = None
     location_id: int | None = None
     video_path: str | None = None
+    chain_from_prev: bool | None = None
 
 
 class SceneReorder(BaseModel):

--- a/calliope-backend/src/calliope/queue/worker.py
+++ b/calliope-backend/src/calliope/queue/worker.py
@@ -128,6 +128,10 @@ class QueueWorker:
                 raise RuntimeError("No workflow found for job")
 
             input_values = payload.get("input_values") or {}
+            if payload.get("chain_from_prev") and kind == "video":
+                input_values = await self._apply_chain_from_prev(
+                    job, payload, workflow, dict(input_values)
+                )
             patched = patch_workflow(workflow, input_values)
             patched = await client.prepare_media_inputs(patched)
             prompt_id = await client.queue_prompt(patched)
@@ -160,6 +164,116 @@ class QueueWorker:
             return paths
         finally:
             await client.close()
+
+    async def _apply_chain_from_prev(
+        self,
+        job: dict[str, Any],
+        payload: dict[str, Any],
+        workflow: dict[str, Any],
+        input_values: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Start this clip from the previous scene's last frame.
+
+        Runs at job time — in a batch the previous scene has rendered by now even
+        though it had not at enqueue time. Extracts the nearest earlier scene's
+        last frame and swaps it into the slot that held the location/first-image
+        reference (found by value; falls back to the location-role node). If no
+        previous clip exists, the job proceeds with its original refs.
+        """
+        import subprocess
+
+        from calliope.comfyui.parser import parse_dynamic_inputs
+        from calliope.comfyui.roles import normalize_input_role
+
+        project_id = job["project_id"]
+        order_index = payload.get("scene_order_index")
+        prev_clip: str | None = None
+        conn = get_db(config.settings.db_path)
+        try:
+            rows = conn.execute(
+                """
+                SELECT video_path FROM scenes
+                WHERE project_id = ? AND order_index < ? AND video_path IS NOT NULL
+                ORDER BY order_index DESC
+                """,
+                (project_id, order_index if order_index is not None else 0),
+            ).fetchall()
+            for r in rows:
+                from pathlib import Path as _P
+
+                if r["video_path"] and _P(r["video_path"]).exists():
+                    prev_clip = r["video_path"]
+                    break
+        finally:
+            conn.close()
+
+        if not prev_clip:
+            await event_bus.publish(
+                "job.progress",
+                {
+                    "job_id": job["id"],
+                    "project_id": project_id,
+                    "message": "Chain-from-previous: no earlier clip yet — using the scene's own refs",
+                },
+            )
+            return input_values
+
+        from pathlib import Path
+
+        frame_dir = config.settings.assets_dir / str(project_id) / "chain"
+        frame_dir.mkdir(parents=True, exist_ok=True)
+        frame = frame_dir / f"scene{job.get('scene_id')}_from_prev.png"
+        proc = subprocess.run(
+            ["ffmpeg", "-y", "-v", "error", "-sseof", "-0.1", "-i", prev_clip,
+             "-update", "1", "-vframes", "1", str(frame)],
+            capture_output=True, text=True, timeout=60,
+        )
+        if proc.returncode != 0 or not frame.exists():
+            await event_bus.publish(
+                "job.progress",
+                {
+                    "job_id": job["id"],
+                    "project_id": project_id,
+                    "message": f"Chain-from-previous: frame extraction failed ({proc.stderr[:120]}) — using original refs",
+                },
+            )
+            return input_values
+
+        # Find the slot to replace: the node holding the enqueue-time location value,
+        # else the workflow's location-role input (may be empty when no location is set).
+        replace_value = payload.get("chain_replace_value")
+        target_node: str | None = None
+        if replace_value:
+            for node_id, value in input_values.items():
+                if value == replace_value:
+                    target_node = str(node_id)
+                    break
+        if target_node is None:
+            for inp in parse_dynamic_inputs(workflow):
+                if normalize_input_role(inp.get("role")) == "location":
+                    target_node = str(inp["nodeId"])
+                    break
+        if target_node is None:
+            await event_bus.publish(
+                "job.progress",
+                {
+                    "job_id": job["id"],
+                    "project_id": project_id,
+                    "message": "Chain-from-previous: no ref slot found to carry the frame — using original refs",
+                },
+            )
+            return input_values
+
+        input_values[target_node] = str(frame)
+        await event_bus.publish(
+            "job.progress",
+            {
+                "job_id": job["id"],
+                "project_id": project_id,
+                "message": "Chain-from-previous: starting from the previous clip's last frame",
+            },
+        )
+        return input_values
 
     async def _dry_run(self, job: dict[str, Any], payload: dict[str, Any]) -> list[str]:
         project_id = job["project_id"]

--- a/calliope-web/src/lib/comfy/types.ts
+++ b/calliope-web/src/lib/comfy/types.ts
@@ -65,6 +65,7 @@ export interface Scene {
 	env_image_path: string | null;
 	location_id: number | null;
 	video_path: string | null;
+	chain_from_prev?: number | boolean | null;
 	character_ids: number[];
 	characters: Array<{
 		id: number;

--- a/calliope-web/src/lib/components/ScriptStage.svelte
+++ b/calliope-web/src/lib/components/ScriptStage.svelte
@@ -106,6 +106,23 @@
 		},
 	});
 
+	// Chain-from-previous toggle — persists on the scene; consumed at render time.
+	let chainPendingId = $state<number | null>(null);
+	async function toggleChain(scene: Scene) {
+		if (chainPendingId != null) return;
+		chainPendingId = scene.id;
+		try {
+			await projects.updateScene(projectId, scene.id, {
+				chain_from_prev: !scene.chain_from_prev,
+			});
+			await client.invalidateQueries({ queryKey: ['scenes'] });
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Could not update scene');
+		} finally {
+			chainPendingId = null;
+		}
+	}
+
 	function jobForScene(sceneId: number): Job | undefined {
 		const jobs = ($jobsQuery.data ?? []).filter(
 			(j) => j.scene_id === sceneId && j.kind === 'video',
@@ -386,6 +403,19 @@
 					{#if scene.duration_sec}
 						<span class="chip"><Icon name="clock" size={12} /> {formatClock(scene.duration_sec)}</span>
 					{/if}
+					{#if i > 0}
+						<button
+							type="button"
+							class="chip chip-toggle"
+							class:chip-on={Boolean(scene.chain_from_prev)}
+							disabled={chainPendingId === scene.id}
+							title="When on, this clip's <Picture 1> / first image is the LAST FRAME of the previous scene's clip (resolved when the render actually runs, so batches chain correctly). Replaces the location reference for this scene."
+							onclick={() => toggleChain(scene)}
+						>
+							<Icon name="film" size={12} />
+							{Boolean(scene.chain_from_prev) ? 'Chained from prev clip' : 'Chain from prev clip'}
+						</button>
+					{/if}
 				</div>
 			</article>
 		{/each}
@@ -629,6 +659,23 @@
 		padding: 2px 10px;
 		font-size: 12px;
 		color: var(--text-secondary);
+	}
+	.chip-toggle {
+		cursor: pointer;
+		font-family: inherit;
+	}
+	.chip-toggle:hover {
+		color: var(--text-primary);
+		border-color: #52525b;
+	}
+	.chip-toggle:disabled {
+		opacity: 0.6;
+		cursor: wait;
+	}
+	.chip-on {
+		color: var(--accent);
+		border-color: var(--accent);
+		background: color-mix(in srgb, var(--accent) 12%, var(--bg-elevated));
 	}
 	.avatar {
 		position: relative;


### PR DESCRIPTION
Scene-to-scene visual continuity: when the toggle is on for a scene, its video generation
uses the **last frame of the previous scene's clip** in place of the location reference.

- **Persistence**: new `scenes.chain_from_prev` column via the existing additive-migration
  pattern in `migrate_db`; exposed through `SceneUpdate`; toggle chip on every Script-tab
  scene card except the first.
- **Resolved at job run time, not enqueue time** — the load-bearing choice: when a whole
  timeline is queued at once, scene N is enqueued before scene N−1 has rendered. The worker
  is sequential, so at run time the previous clip exists. The worker finds the nearest
  earlier scene with a clip, extracts its last frame (ffmpeg — already a runtime dependency
  for export), and swaps it into whichever slot held the location image. The slot is located
  **by value match** against the enqueue-time location path, so it works with any workflow
  layout (generic ref slots or role-tagged), with the location-role node as fallback.
- **Graceful degradation**: no previous clip yet, or extraction fails → the job proceeds with
  the scene's own refs and posts an event-bus notice. Never a hard failure.

On reference-style video workflows this gives scene-to-scene continuity (the frame acts as
the scene reference); on workflows with a pinned first-image slot it opens frame-exact.
Verified end to end against a real ComfyUI backend, including the queued-batch case.
