### PR TITLE
Model per agent LLMs + clip-native export FPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,6 @@ calliope-backend/dist/
 node_modules/
 calliope-web/build/
 calliope-web/.svelte-kit/
-electron/dist/
-electron/builder-debug.yml
 
 # --- Build artifacts (generated, not source) ---
 calliope-backend/src/calliope/static/
@@ -35,6 +33,7 @@ calliope-backend/src/calliope/static/
 *.log
 
 # --- Local-only files (not part of the public repo) ---
+# Electron shell was dropped — keep ignoring so a leftover folder cannot be committed.
 electron/
 AGENTS.md
 start.bat

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Open `http://127.0.0.1:5173`. The dev server proxies `/api` to the backend on `1
 
 Open the app, go to **Settings**, and set:
 
-1. **LLM** — base URL, model name, and API key of your OpenAI-compatible endpoint
+1. **LLM** — one or more OpenAI-compatible endpoints (base URL, model name, API key). Save several, then pick which one is **Active**.
 2. **ComfyUI** — the base URL of your running ComfyUI (e.g. `http://127.0.0.1:8188`)
+3. **Agent** *(optional)* — assign a specific LLM per agent role (see below)
 
 Leave **Dry-run** off — it is meant for testing and produces placeholder results instead of real generations.
 
@@ -60,6 +61,13 @@ In **Settings → Queue** you can tune how the worker talks to ComfyUI:
 - **Poll timeout (seconds)** — how long Calliope keeps waiting on ComfyUI for a single job before failing it. **Default is `1800` (30 minutes).** Long video generations can easily exceed 10 minutes, so raise this for heavy workflows — or set it to **`0` to wait indefinitely** (until the job finishes or you cancel it).
 - **Max retries** — automatic retries before a job is marked failed.
 
+### Agent settings
+
+In **Settings → Agent**:
+
+- **Model per agent** — assign any saved LLM to each role: **Main agent, Planner, Story agent, Script agent, Assets agent, Video agent**. Blank means the **Active LLM** from Settings → LLM applies, so a single-endpoint setup needs no configuration here. A common setup is a strong cloud model for the main agent and planner, and a fast local model for the sub-agents. The Video agent's assignment also drives the MiniMax H3 prompt rewrite.
+- **System-prompt rules (hardening)** — operator rules appended to every agent system prompt. Leave blank to disable.
+
 ## Using the app
 
 The app walks a project through four stages — **Story, Assets, Script, Video**:
@@ -68,7 +76,7 @@ The app walks a project through four stages — **Story, Assets, Script, Video**
 - **Assets:** each character, location, and item has its own **Image prompt**. Pick a workflow and shared settings (width/height/etc.) at the top, then click Generate per entity to produce reference images on your ComfyUI. Regenerate any single entity without touching the others.
 - **Script:** **Regenerate Script** also opens a project-linked Agents chat (pre-filled) to rewrite the per-scene script. Scenes link back to the characters and locations from the Story stage.
 - **Video:** each scene gets a **Generate** button that queues a clip job on ComfyUI with the right prompt and reference images (plus optional video/audio file refs). Import a FirstMotion + NextMotion H3 pair to chain clips: clip 1 starts a motion, clips 2+ continue the last 22 frames and 1s of audio from the previous latent so the export stitch reads as one long take.
-- **Film view:** once scenes have clips, **Export film** stitches them with ffmpeg: every clip is normalized to 1080p30, joined with 0.5s crossfades, and loudness-normalized into one final file.
+- **Film view:** once scenes have clips, **Export film** stitches them with ffmpeg: clips are normalized to 1080p at the **majority frame rate of the clips themselves** (24 fps clips export at 24 fps; mixed-rate projects conform to whichever rate most clips use), joined with 0.5s crossfades, and loudness-normalized into one final file.
 - When everything is done the project is automatically marked **Completed**.
 
 **Playground** is a free-form generation page outside the project pipeline: run any imported workflow with arbitrary inputs, upload your own files (image / video / audio) as inputs, and optionally attach a result to a project as an asset.

--- a/calliope-backend/.gitignore
+++ b/calliope-backend/.gitignore
@@ -1,0 +1,18 @@
+# --- Secrets & user data (NEVER commit) ---
+calliope_config.json
+data/
+*.db
+*.db-wal
+*.db-shm
+.env
+.env.*
+
+# --- Python ---
+.venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+build/
+dist/
+*.egg-info/

--- a/calliope-backend/src/calliope/agent/harness/__init__.py
+++ b/calliope-backend/src/calliope/agent/harness/__init__.py
@@ -85,10 +85,11 @@ def _destructive_guard(ctx: ToolContext, t: ToolDefinition, args: dict) -> PreEx
     if not has_replace_param:
         return allow()
     replace = bool(args.get("replace", True))
-    if not replace:
-        return allow()
-    # Destructive path: only allow when the project is effectively empty, or
-    # the user explicitly confirmed.
+    # BOTH modes are gated on a non-empty project: replace=true deletes the
+    # existing content, and replace=false APPENDS a second full set alongside
+    # it (observed live 2026-08-25: an unconfirmed replace=false generate_story
+    # silently doubled a project's beats, 25 -> 50). Only allow when the
+    # project is effectively empty, or the user explicitly confirmed.
     from calliope.agent.harness.registry import _db
 
     if ctx.project_id is None:
@@ -117,11 +118,25 @@ def _destructive_guard(ctx: ToolContext, t: ToolDefinition, args: dict) -> PreEx
         return allow()
     if _user_confirmed_replacement(ctx):
         return allow()
-    return deny(
+    counts = (
         f"Project #{ctx.project_id} already has content ({scenes} scenes, {beats} beats, "
-        f"{chars} characters, {locs} locations, {items} items). Ask the user to confirm before replacing; "
-        "once they confirm (e.g. 'yes, replace'), call this tool again. "
-        "To append instead, pass replace=false."
+        f"{chars} characters, {locs} locations, {items} items)."
+    )
+    if replace:
+        return deny(
+            counts + " replace=true DELETES all of it first. Ask the user to "
+            "confirm before replacing; once they confirm (e.g. 'yes, replace'), "
+            "call this tool again. For targeted changes use the granular tools "
+            "instead (add/update/delete for beats, characters, locations, "
+            "items, scenes)."
+        )
+    return deny(
+        counts + " replace=false would APPEND a second full set alongside the "
+        "existing content (e.g. doubling the beat list) — usually wrong. Ask "
+        "the user to confirm before appending; once they confirm (e.g. 'yes, "
+        "append'), call this tool again. For targeted changes use the granular "
+        "tools instead (add/update/delete for beats, characters, locations, "
+        "items, scenes)."
     )
 
 

--- a/calliope-backend/src/calliope/agent/harness/log.py
+++ b/calliope-backend/src/calliope/agent/harness/log.py
@@ -37,6 +37,16 @@ TASK_START = "task/start"
 TASK_END = "task/end"
 
 TOOL_RESULT_TRUNCATE = 4000
+# Appended wherever a tool result is cut for the LLM. Must TEACH the way out —
+# a bare "[truncated]" sends agents into retry loops hoping for a different
+# cut (observed live 2026-08-24: an assets sub-agent re-called get_workspace
+# repeatedly, blind to characters/locations below the cut).
+TRUNCATE_NOTE = (
+    "…[truncated — the full result is too large for one reply. Fetch a "
+    "smaller slice instead of retrying: get_workspace accepts "
+    "sections=[\"characters\",\"locations\",\"items\",\"beats\",\"scenes\"], "
+    "and scoped tools (get_story, list_scenes) return less.]"
+)
 
 # Cap for ANY single event payload at append time: keeps the append-only log
 # faithful in shape but bounded in size (a 500 KB tool result would otherwise
@@ -311,7 +321,7 @@ def derive_llm_history(
 def _truncate_result(result: Any) -> str:
     text = json.dumps(result, ensure_ascii=False, default=str)
     if len(text) > TOOL_RESULT_TRUNCATE:
-        return text[:TOOL_RESULT_TRUNCATE] + "…[truncated]"
+        return text[:TOOL_RESULT_TRUNCATE] + TRUNCATE_NOTE
     return text
 
 

--- a/calliope-backend/src/calliope/agent/harness/loop.py
+++ b/calliope-backend/src/calliope/agent/harness/loop.py
@@ -38,6 +38,16 @@ def _default_max_iterations() -> int:
     except (TypeError, ValueError):
         return MAX_ITERATIONS
 
+
+def _llm_for_role(role: str) -> LLMClient:
+    # Tests patch loop.LLMClient with zero-arg fakes that lack for_role;
+    # prefer role resolution, fall back to a bare instance.
+    factory = LLMClient
+    for_role = getattr(factory, "for_role", None)
+    if callable(for_role):
+        return for_role(role)
+    return factory()
+
 # Async callback that persists + broadcasts one harness message.
 MessageSink = Callable[[dict[str, Any]], Awaitable[None]]
 
@@ -77,7 +87,7 @@ async def run_turn(
     turn_no = _next_turn_number(ctx.session_id)
     log_append(session_log.TURN_START, {"turn": turn_no})
 
-    client = LLMClient()
+    client = _llm_for_role("main")
     final_text = ""
     turn_status = "completed"
     try:

--- a/calliope-backend/src/calliope/agent/harness/loop.py
+++ b/calliope-backend/src/calliope/agent/harness/loop.py
@@ -242,7 +242,7 @@ async def run_turn(
                 )
                 result_text = json.dumps(result, ensure_ascii=False, default=str)
                 if len(result_text) > session_log.TOOL_RESULT_TRUNCATE:
-                    result_text = result_text[: session_log.TOOL_RESULT_TRUNCATE] + "…[truncated]"
+                    result_text = result_text[: session_log.TOOL_RESULT_TRUNCATE] + session_log.TRUNCATE_NOTE
                 messages.append(
                     {
                         "role": "tool",

--- a/calliope-backend/src/calliope/agent/harness/orchestrator.py
+++ b/calliope-backend/src/calliope/agent/harness/orchestrator.py
@@ -24,6 +24,16 @@ from calliope.events.bus import event_bus
 
 logger = logging.getLogger("calliope.harness.orchestrator")
 
+
+def _llm_for_role(role: str) -> LLMClient:
+    # Tests patch orch.LLMClient with zero-arg fakes that lack for_role;
+    # prefer role resolution, fall back to a bare instance.
+    factory = LLMClient
+    for_role = getattr(factory, "for_role", None)
+    if callable(for_role):
+        return for_role(role)
+    return factory()
+
 # LLM context window bound: the last N user turns are replayed into each
 # request. Tool exchanges never span user turns, so tool_call/result pairs
 # always survive the trim intact.
@@ -125,7 +135,7 @@ def _scoped_payload(ctx: ToolContext, allowed: list[str]) -> list[dict[str, Any]
 
 
 async def _plan(goal: str, workspace_summary: str) -> dict[str, Any]:
-    client = LLMClient()
+    client = _llm_for_role("planner")
     try:
         text = await client.chat(
             [
@@ -337,7 +347,7 @@ async def orchestrate(
         + "\n\nWrite a concise final summary for the user: what was done, "
         "job ids enqueued, and any failures. Plain text."
     )
-    client = LLMClient()
+    client = _llm_for_role("planner")
     try:
         final = await client.chat(
             [
@@ -390,7 +400,8 @@ async def _run_sub_agent(
         else:
             await event_bus.publish("agent.message", {"session_id": ctx.session_id, **message})
 
-    client = LLMClient()
+    role = agent_name.removesuffix("-agent")
+    client = _llm_for_role(role)
     messages = list(sub_history)
     system = (
         "You are a specialized sub-agent in Calliope's production swarm. "

--- a/calliope-backend/src/calliope/agent/harness/orchestrator.py
+++ b/calliope-backend/src/calliope/agent/harness/orchestrator.py
@@ -32,7 +32,15 @@ MAX_HISTORY_USER_TURNS = 40
 # Tool subsets per sub-agent role. Scoped tighter than the full registry so a
 # sub-agent cannot wander into another role's tools.
 ROLE_TOOLS: dict[str, list[str]] = {
-    "story": ["get_workspace", "get_story", "generate_story", "list_workflows"],
+    "story": [
+        "get_workspace",
+        "get_story",
+        "generate_story",
+        "add_beat",
+        "update_beat",
+        "delete_beat",
+        "list_workflows",
+    ],
     "script": [
         "get_workspace",
         "list_scenes",
@@ -44,6 +52,9 @@ ROLE_TOOLS: dict[str, list[str]] = {
     ],
     "assets": [
         "get_workspace",
+        "update_character",
+        "update_location",
+        "update_item",
         "list_workflows",
         "comfy_server_info",
         "run_workflow",
@@ -285,7 +296,14 @@ async def orchestrate(
                 }
             )
         except Exception as exc:  # noqa: BLE001
-            results.append(f"[{role}] FAILED: {exc}")
+            # Some exceptions stringify EMPTY (httpx.ReadTimeout/ReadError,
+            # TimeoutError) — always name the type, and keep the traceback
+            # (observed live 2026-08-25: "Sub-agent failed: " with nothing
+            # after the colon, because a deploy restart killed the in-flight
+            # stream and the ReadError carried no message).
+            logger.exception("Sub-agent %s failed", role)
+            detail = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
+            results.append(f"[{role}] FAILED: {detail}")
             session_log.append_event(
                 session_id,
                 session_log.TASK_END,
@@ -298,7 +316,7 @@ async def orchestrate(
                 session_id,
                 session_log.ASSISTANT_MESSAGE,
                 {
-                    "content": f"Sub-agent failed: {exc}",
+                    "content": f"Sub-agent failed: {detail}",
                     "agent_name": f"{role}-agent",
                     "status": "error",
                 },
@@ -307,7 +325,7 @@ async def orchestrate(
                 {
                     "role": "assistant",
                     "agent_name": f"{role}-agent",
-                    "content": f"Sub-agent failed: {exc}",
+                    "content": f"Sub-agent failed: {detail}",
                     "status": "error",
                 }
             )
@@ -471,7 +489,7 @@ async def _run_sub_agent(
                 )
                 result_text = json.dumps(result, ensure_ascii=False, default=str)
                 if len(result_text) > session_log.TOOL_RESULT_TRUNCATE:
-                    result_text = result_text[: session_log.TOOL_RESULT_TRUNCATE] + "…[truncated]"
+                    result_text = result_text[: session_log.TOOL_RESULT_TRUNCATE] + session_log.TRUNCATE_NOTE
                 messages.append(
                     {"role": "tool", "tool_call_id": call_id, "content": result_text}
                 )

--- a/calliope-backend/src/calliope/agent/harness/plugins/story.py
+++ b/calliope-backend/src/calliope/agent/harness/plugins/story.py
@@ -52,6 +52,182 @@ def register(registry: ToolRegistry) -> None:
         )
     )
     _register_asset_crud(registry)
+    _register_beat_crud(registry)
+
+
+def _register_beat_crud(registry: ToolRegistry) -> None:
+    """Register add/update/delete tools for story beats.
+
+    Before these existed, beats could ONLY be changed via generate_story —
+    a bulk regenerate — so "align the beats to this story" left an agent no
+    non-destructive path (observed live 2026-08-25: a story sub-agent, boxed
+    in, appended a duplicate 25-beat set and then hit the destructive guard).
+    """
+    registry.register(
+        ToolDefinition(
+            name="add_beat",
+            description=(
+                "Insert one story beat. title is required. order_index is the "
+                "1-based timeline position — later beats shift down to make "
+                "room; omit it to append at the end."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "description": {"type": "string"},
+                    "order_index": {
+                        "type": "integer",
+                        "description": "1-based position; omit to append at the end",
+                    },
+                },
+                "required": ["title"],
+            },
+            executor=t_add_beat,
+            category="story",
+        )
+    )
+    registry.register(
+        ToolDefinition(
+            name="update_beat",
+            description=(
+                "Update one existing story beat. beat_id must come from "
+                "get_story/get_workspace — never guess it. Pass only the fields "
+                "to change (title, description, order_index)."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "beat_id": {"type": "integer"},
+                    "title": {"type": "string"},
+                    "description": {"type": "string"},
+                    "order_index": {"type": "integer"},
+                },
+                "required": ["beat_id"],
+            },
+            executor=t_update_beat,
+            category="story",
+        )
+    )
+    registry.register(
+        ToolDefinition(
+            name="delete_beat",
+            description=(
+                "Delete one story beat permanently; later beats renumber to "
+                "close the gap. beat_id must come from get_story/get_workspace. "
+                "Prefer update_beat for content changes."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {"beat_id": {"type": "integer"}},
+                "required": ["beat_id"],
+            },
+            executor=t_delete_beat,
+            category="story",
+            destructive=True,
+        )
+    )
+
+
+async def t_add_beat(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+    title = args.get("title")
+    if not isinstance(title, str) or not title.strip():
+        return {"ok": False, "error": "title is required (non-empty string)"}
+    conn = _db()
+    try:
+        max_idx = conn.execute(
+            "SELECT COALESCE(MAX(order_index), 0) AS m FROM story_beats WHERE project_id = ?",
+            (ctx.project_id,),
+        ).fetchone()["m"]
+        idx = args.get("order_index")
+        idx = int(idx) if idx is not None else max_idx + 1
+        idx = max(1, min(idx, max_idx + 1))
+        conn.execute(
+            "UPDATE story_beats SET order_index = order_index + 1 "
+            "WHERE project_id = ? AND order_index >= ?",
+            (ctx.project_id, idx),
+        )
+        cur = conn.execute(
+            "INSERT INTO story_beats (project_id, order_index, title, description) "
+            "VALUES (?, ?, ?, ?)",
+            (ctx.project_id, idx, title.strip(), args.get("description")),
+        )
+        conn.execute(
+            "UPDATE projects SET updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (ctx.project_id,),
+        )
+        conn.commit()
+        beat = conn.execute(
+            "SELECT * FROM story_beats WHERE id = ?", (cur.lastrowid,)
+        ).fetchone()
+        return {"ok": True, "beat": row_to_dict(beat)}
+    finally:
+        conn.close()
+
+
+async def t_update_beat(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+    bid = int(args["beat_id"])
+    data = {
+        k: v
+        for k, v in args.items()
+        if k in ("title", "description", "order_index") and v is not None
+    }
+    if "title" in data and not str(data["title"]).strip():
+        data.pop("title")
+    conn = _db()
+    try:
+        existing = conn.execute(
+            "SELECT id FROM story_beats WHERE id = ? AND project_id = ?",
+            (bid, ctx.project_id),
+        ).fetchone()
+        if not existing:
+            return {"ok": False, "error": f"Beat {bid} not found in this project"}
+        if data:
+            fields = ", ".join(f"{k} = :{k}" for k in data)
+            conn.execute(
+                f"UPDATE story_beats SET {fields} WHERE id = :id AND project_id = :project_id",
+                {**data, "id": bid, "project_id": ctx.project_id},
+            )
+            conn.execute(
+                "UPDATE projects SET updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (ctx.project_id,),
+            )
+            conn.commit()
+        beat = conn.execute(
+            "SELECT * FROM story_beats WHERE id = ?", (bid,)
+        ).fetchone()
+        return {"ok": True, "beat": row_to_dict(beat)}
+    finally:
+        conn.close()
+
+
+async def t_delete_beat(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+    bid = int(args["beat_id"])
+    conn = _db()
+    try:
+        row = conn.execute(
+            "SELECT order_index FROM story_beats WHERE id = ? AND project_id = ?",
+            (bid, ctx.project_id),
+        ).fetchone()
+        if not row:
+            return {"ok": False, "error": f"Beat {bid} not found in this project"}
+        conn.execute(
+            "DELETE FROM story_beats WHERE id = ? AND project_id = ?",
+            (bid, ctx.project_id),
+        )
+        conn.execute(
+            "UPDATE story_beats SET order_index = order_index - 1 "
+            "WHERE project_id = ? AND order_index > ?",
+            (ctx.project_id, row["order_index"]),
+        )
+        conn.execute(
+            "UPDATE projects SET updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (ctx.project_id,),
+        )
+        conn.commit()
+        return {"ok": True, "deleted_beat_id": bid}
+    finally:
+        conn.close()
 
 
 def _register_asset_crud(registry: ToolRegistry) -> None:

--- a/calliope-backend/src/calliope/agent/harness/plugins/workspace.py
+++ b/calliope-backend/src/calliope/agent/harness/plugins/workspace.py
@@ -21,11 +21,35 @@ def register(registry: ToolRegistry) -> None:
             name="get_workspace",
             description=(
                 "Get the current workspace: session linkage and, when linked, "
-                "the project with story beats, characters, locations, scenes, "
-                "and stats. ALWAYS call this before editing anything or when "
-                "you need current ids/counts."
+                "the project with story beats, characters, locations, items, "
+                "scenes, and stats. ALWAYS call this before editing anything or "
+                "when you need current ids/counts. On a LARGE project the full "
+                "result gets truncated — pass sections (e.g. "
+                "[\"characters\",\"locations\",\"items\"]) to fetch only what "
+                "you need; project + stats are always included."
             ),
-            parameters={"type": "object", "properties": {}},
+            parameters={
+                "type": "object",
+                "properties": {
+                    "sections": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "beats",
+                                "characters",
+                                "locations",
+                                "items",
+                                "scenes",
+                            ],
+                        },
+                        "description": (
+                            "Which sections to include. Omit for all — but on "
+                            "large projects prefer only the sections you need."
+                        ),
+                    }
+                },
+            },
             executor=t_get_workspace,
             requires_project=False,
             category="workspace",
@@ -37,7 +61,8 @@ def register(registry: ToolRegistry) -> None:
             description=(
                 "Link this sandbox session to an EXISTING project (call "
                 "list_projects first to get valid ids). Only possible while the "
-                "session is not yet linked — do NOT create a duplicate project "
+                "session is not yet linked — to switch projects, call "
+                "unlink_project first. Do NOT create a duplicate project "
                 "when one already matches."
             ),
             parameters={
@@ -53,6 +78,21 @@ def register(registry: ToolRegistry) -> None:
             executor=t_link_project,
             requires_project=False,
             blind_only=True,
+            category="workspace",
+        )
+    )
+    registry.register(
+        ToolDefinition(
+            name="unlink_project",
+            description=(
+                "Detach this session from its linked project and return to "
+                "sandbox mode. The project and all its content are untouched — "
+                "only the session binding is cleared. Use this when the user "
+                "wants a NEW project (then create_project) or a DIFFERENT "
+                "existing one (then link_project). Not available in sandbox."
+            ),
+            parameters={"type": "object", "properties": {}},
+            executor=t_unlink_project,
             category="workspace",
         )
     )
@@ -127,6 +167,9 @@ def register(registry: ToolRegistry) -> None:
     )
 
 
+_WS_SECTIONS = ("beats", "characters", "locations", "items", "scenes")
+
+
 # ── executors ───────────────────────────────────────────────────
 
 
@@ -154,6 +197,16 @@ async def t_get_workspace(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
             out["mode"] = "sandbox"
             out["hint"] = "Linked project no longer exists."
             return out
+        requested = args.get("sections")
+        if requested:
+            wanted = {sec for sec in requested if sec in _WS_SECTIONS}
+            if not wanted:
+                return {
+                    "ok": False,
+                    "error": f"No valid sections in {requested!r}; valid: {sorted(_WS_SECTIONS)}",
+                }
+        else:
+            wanted = set(_WS_SECTIONS)
         beats = [
             row_to_dict(r)
             for r in conn.execute(
@@ -161,7 +214,7 @@ async def t_get_workspace(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
                 "WHERE project_id = ? ORDER BY order_index",
                 (ctx.project_id,),
             ).fetchall()
-        ]
+        ] if "beats" in wanted else None
         characters = [
             row_to_dict(r)
             for r in conn.execute(
@@ -169,7 +222,7 @@ async def t_get_workspace(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
                 "sheet_path, consistency_prompt FROM characters WHERE project_id = ?",
                 (ctx.project_id,),
             ).fetchall()
-        ]
+        ] if "characters" in wanted else None
         locations = [
             row_to_dict(r)
             for r in conn.execute(
@@ -177,7 +230,7 @@ async def t_get_workspace(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
                 "FROM locations WHERE project_id = ?",
                 (ctx.project_id,),
             ).fetchall()
-        ]
+        ] if "locations" in wanted else None
         items = [
             row_to_dict(r)
             for r in conn.execute(
@@ -185,7 +238,7 @@ async def t_get_workspace(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
                 "FROM items WHERE project_id = ?",
                 (ctx.project_id,),
             ).fetchall()
-        ]
+        ] if "items" in wanted else None
         scenes = [
             row_to_dict(r)
             for r in conn.execute(
@@ -193,15 +246,21 @@ async def t_get_workspace(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
                 "location_id, video_path FROM scenes WHERE project_id = ? ORDER BY order_index",
                 (ctx.project_id,),
             ).fetchall()
-        ]
+        ] if "scenes" in wanted else None
         out["mode"] = "linked"
         out["project"] = project
         out["stats"] = _project_stats(ctx.project_id, conn)
-        out["beats"] = beats
-        out["characters"] = characters
-        out["locations"] = locations
-        out["items"] = items
-        out["scenes"] = scenes
+        for key, value in (
+            ("beats", beats),
+            ("characters", characters),
+            ("locations", locations),
+            ("items", items),
+            ("scenes", scenes),
+        ):
+            if value is not None:
+                out[key] = value
+        if len(wanted) < len(_WS_SECTIONS):
+            out["sections_omitted"] = sorted(set(_WS_SECTIONS) - wanted)
         return out
     finally:
         conn.close()
@@ -226,6 +285,29 @@ async def t_link_project(ctx: ToolContext, args: dict[str, Any]) -> dict[str, An
     ctx.project_id = pid
     await publish_session_updated(ctx.session_id)
     return {"ok": True, "project_id": pid, "title": project["title"]}
+
+
+async def t_unlink_project(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+    released_id = ctx.project_id
+    conn = _db()
+    try:
+        project = _project_or_error(conn, released_id)
+        conn.execute(
+            "UPDATE agent_sessions SET project_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (ctx.session_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    ctx.project_id = None
+    await publish_session_updated(ctx.session_id)
+    return {
+        "ok": True,
+        "released_project_id": released_id,
+        "released_title": (project or {}).get("title"),
+        "mode": "sandbox",
+        "hint": "Session is back in sandbox — create_project and link_project are available again.",
+    }
 
 
 _TITLE_MAX = 200  # mirrors ProjectCreate/ProjectUpdate schema bounds

--- a/calliope-backend/src/calliope/agent/harness/policy.py
+++ b/calliope-backend/src/calliope/agent/harness/policy.py
@@ -14,7 +14,7 @@ from calliope.agent.harness.registry import ToolContext
 # (or "replace it" / "start over") for the destructive guard.
 _CONFIRM_RE = re.compile(
     r"\b(yes|yeah|yep|yup|sure|ok|okay|k|confirm(?:ed)?|proceed|"
-    r"go\s+ahead|do\s+it|please\s+do|overwrite|replace|regenerate|"
+    r"go\s+ahead|do\s+it|please\s+do|overwrite|replace|append|regenerate|"
     r"redo|re-?do|start\s+over|restart|delete|wipe|reset|from\s+scratch|"
     r"go\s+for\s+it|fine|sounds\s+good|that'?s\s+fine)\b",
     re.IGNORECASE,

--- a/calliope-backend/src/calliope/agent/harness/registry.py
+++ b/calliope-backend/src/calliope/agent/harness/registry.py
@@ -161,7 +161,13 @@ class ToolRegistry:
                 "error": "This tool requires a linked project. Create one with create_project first.",
             }
         if t.blind_only and ctx.project_id is not None:
-            return {"ok": False, "error": "This tool is only available in a sandbox (unlinked) session."}
+            return {
+                "ok": False,
+                "error": (
+                    "This tool is only available in a sandbox (unlinked) session. "
+                    "Call unlink_project first to return this session to sandbox."
+                ),
+            }
 
         decision = ALLOW
         for hook in self.pre_execute:

--- a/calliope-backend/src/calliope/agent/llm.py
+++ b/calliope-backend/src/calliope/agent/llm.py
@@ -17,16 +17,31 @@ _STREAM_UNSUPPORTED_STATUS = frozenset({400, 404, 405, 501})
 
 
 class LLMClient:
-    def __init__(self) -> None:
-        self.base_url = settings.llm_base_url.rstrip("/")
-        self.model = settings.llm_model
-        self.api_key = settings.llm_api_key
+    def __init__(
+        self,
+        base_url: str | None = None,
+        model: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        self.base_url = (base_url or settings.llm_base_url).rstrip("/")
+        self.model = model or settings.llm_model
+        self.api_key = api_key if api_key is not None else settings.llm_api_key
         # With every completion streamed (chat/chat_with_tools consume
         # chat_stream), 120 s bounds the gap BETWEEN chunks, not total
         # generation time: a thinking model streaming reasoning_content keeps
         # the connection fed for as long as it genuinely works, while a dead
         # server still fails fast.
         self.client = httpx.AsyncClient(timeout=120.0)
+
+    @classmethod
+    def for_role(cls, role: str) -> LLMClient:
+        """Client for an agent role's assigned profile (active fallback)."""
+        profile = settings.resolve_llm_for_role(role)
+        return cls(
+            base_url=profile.get("base_url"),
+            model=profile.get("model"),
+            api_key=profile.get("api_key") if isinstance(profile.get("api_key"), str) else None,
+        )
 
     def _headers(self) -> dict[str, str]:
         headers = {"Content-Type": "application/json"}

--- a/calliope-backend/src/calliope/agent/video_agent.py
+++ b/calliope-backend/src/calliope/agent/video_agent.py
@@ -69,7 +69,7 @@ def _h3_subjects(
 
 async def _h3_rewrite(scene: dict[str, Any], subjects: list[dict[str, Any]]) -> str:
     """LLM rewrite into H3's six-section format, deterministic template on failure."""
-    client = LLMClient()
+    client = LLMClient.for_role("video")
     try:
         return await client.chat(
             build_minimax_h3_ref_messages(scene, subjects), temperature=0.4

--- a/calliope-backend/src/calliope/config.py
+++ b/calliope-backend/src/calliope/config.py
@@ -56,6 +56,11 @@ DEFAULT_AGENT_HARDENING_PROMPT = """You are operating under additional operator-
 5. CONCISE, HONEST REPLIES: Prefer short, factual answers. State what changed, any ids enqueued, and any failures. Do not overclaim.
 6. ONE STEP AT A TIME: Wait for each tool result before the next call. Never assume a tool succeeded without its result."""
 
+# Agent roles that can be pinned to a specific LLM profile. Values live in
+# Settings.agent_llm_assignments (role -> profile id or None). A missing or
+# None entry means "use the Active LLM".
+AGENT_LLM_ROLES: tuple[str, ...] = ("main", "planner", "story", "script", "assets", "video")
+
 
 def is_ephemeral_path(path: Path | str | None) -> bool:
     """True for OS temp / pytest TemporaryDirectory paths — never use as default storage."""
@@ -105,6 +110,8 @@ class Settings(BaseSettings):
     # profile so LLMClient and env overrides keep working.
     llm_profiles: list[dict[str, Any]] = Field(default_factory=list)
     llm_active_id: str | None = None
+    # role (AGENT_LLM_ROLES) -> LLM profile id; None/absent = use Active LLM
+    agent_llm_assignments: dict[str, str | None] = Field(default_factory=dict)
 
     comfyui_base_url: str = "http://127.0.0.1:8188"
     # Comfy is HTTP-only (upload / prompt / history / view). No local input/output dirs.
@@ -197,6 +204,22 @@ class Settings(BaseSettings):
             self.llm_model = str(profile["model"])
         self.llm_api_key = profile.get("api_key") if isinstance(profile.get("api_key"), str) else None
 
+    def resolve_llm_for_role(self, role: str) -> dict[str, Any]:
+        """Profile dict for an agent role: assignment → active fallback.
+
+        Unknown roles and dangling profile ids fall back to the active
+        profile, mirroring apply_active_llm's leniency.
+        """
+        self.ensure_llm_profiles()
+        assigned_id = (self.agent_llm_assignments or {}).get(role)
+        profiles = self.llm_profiles
+        if assigned_id:
+            for profile in profiles:
+                if profile.get("id") == assigned_id:
+                    return profile
+        active = next((p for p in profiles if p.get("id") == self.llm_active_id), None)
+        return active or profiles[0]
+
     def replace_llm_profiles(self, incoming: list[dict[str, Any]]) -> None:
         """Replace the profile list, preserving secrets unless a new key is sent."""
         existing = {
@@ -232,6 +255,11 @@ class Settings(BaseSettings):
         ids = {p["id"] for p in new_list}
         if self.llm_active_id not in ids:
             self.llm_active_id = new_list[0]["id"]
+        self.agent_llm_assignments = {
+            role: pid
+            for role, pid in (self.agent_llm_assignments or {}).items()
+            if pid is None or pid in ids
+        }
         self.apply_active_llm()
 
     def sync_legacy_llm_into_active(self) -> None:
@@ -277,6 +305,7 @@ class Settings(BaseSettings):
             "llm_api_key": bool(self.llm_api_key),
             "llm_profiles": profiles,
             "llm_active_id": self.llm_active_id,
+            "agent_llm_assignments": dict(self.agent_llm_assignments or {}),
             "comfyui_base_url": self.comfyui_base_url,
             "queue_concurrency": self.queue_concurrency,
             "queue_poll_interval_sec": self.queue_poll_interval_sec,
@@ -358,6 +387,7 @@ class Settings(BaseSettings):
             "llm_api_key": self.llm_api_key,
             "llm_profiles": self.llm_profiles,
             "llm_active_id": self.llm_active_id,
+            "agent_llm_assignments": dict(self.agent_llm_assignments or {}),
             "comfyui_base_url": self.comfyui_base_url,
             "queue_concurrency": self.queue_concurrency,
             "queue_poll_interval_sec": self.queue_poll_interval_sec,

--- a/calliope-backend/src/calliope/export/runner.py
+++ b/calliope-backend/src/calliope/export/runner.py
@@ -270,15 +270,16 @@ async def run_export(
 
     _require_binary("ffmpeg")
     probes = [await probe(clip["video_path"]) for clip in clips]
+    fps = target_fps(probes)
     durations = [float(p["duration"]) for p in probes]
     total_us = (sum(durations) - XFADE_SEC * max(0, len(clips) - 1)) * 1_000_000
 
-    cmd = build_ffmpeg_cmd(clips, probes, dest)
+    cmd = build_ffmpeg_cmd(clips, probes, dest, fps=fps)
     logger.info("Export job %s: %s", job_id, " ".join(cmd))
 
     await bus.publish(
         "job.progress",
-        {"job_id": job_id, "kind": "export", "percent": 0.0, "message": "Exporting film…"},
+        {"job_id": job_id, "kind": "export", "percent": 0.0, "message": f"Exporting film ({fps:.6g} fps)…"},
     )
     last_publish = time.monotonic()
 

--- a/calliope-backend/src/calliope/export/runner.py
+++ b/calliope-backend/src/calliope/export/runner.py
@@ -30,10 +30,6 @@ DEFAULT_EXPORT_FPS = 30.0
 XFADE_SEC = 0.5
 PROGRESS_MIN_INTERVAL_SEC = 1.0
 
-# Retained for the pre-B2 v_chain reference; removed when build_ffmpeg_cmd
-# switches to the voted rate.
-EXPORT_FPS = DEFAULT_EXPORT_FPS
-
 _running: dict[int, asyncio.subprocess.Process] = {}
 
 
@@ -125,7 +121,7 @@ async def probe(path: str | Path) -> dict[str, Any]:
         "-v",
         "error",
         "-show_entries",
-        "format=duration:stream=codec_type",
+        "format=duration:stream=codec_type,r_frame_rate",
         "-of",
         "json",
         str(path),
@@ -138,20 +134,34 @@ async def probe(path: str | Path) -> dict[str, Any]:
         raise RuntimeError(f"ffprobe failed for {path}: {tail}")
     data = json.loads(out.decode("utf-8", "replace") or "{}")
     duration = float((data.get("format") or {}).get("duration") or 0.0)
-    has_audio = any(s.get("codec_type") == "audio" for s in data.get("streams") or [])
-    return {"duration": duration, "has_audio": has_audio}
+    streams = data.get("streams") or []
+    has_audio = any(s.get("codec_type") == "audio" for s in streams)
+    video_fps = 0.0
+    for s in streams:
+        if s.get("codec_type") == "video":
+            video_fps = parse_rate(s.get("r_frame_rate"))
+            break
+    return {"duration": duration, "has_audio": has_audio, "fps": video_fps}
 
 
 def build_ffmpeg_cmd(
     clips: list[dict[str, Any]],
     probes: list[dict[str, Any]],
     dest: str | Path,
+    *,
+    fps: float | None = None,
 ) -> list[str]:
-    """Assemble the validated normalize → xfade → loudnorm ffmpeg command."""
+    """Assemble the validated normalize → xfade → loudnorm ffmpeg command.
+
+    fps=None conforms every clip to target_fps(probes) — the clips' own
+    majority rate. Pass an explicit fps to override the vote.
+    """
     if not clips:
         raise RuntimeError("No clips to export")
     if len(clips) != len(probes):
         raise ValueError("clips and probes must align")
+    rate = float(fps) if fps else target_fps(probes)
+    rate_str = f"{rate:.6g}"
 
     n = len(clips)
     ffmpeg = shutil.which("ffmpeg") or "ffmpeg"
@@ -171,7 +181,7 @@ def build_ffmpeg_cmd(
     v_chain = (
         f"scale={EXPORT_WIDTH}:{EXPORT_HEIGHT}:force_original_aspect_ratio=decrease,"
         f"pad={EXPORT_WIDTH}:{EXPORT_HEIGHT}:(ow-iw)/2:(oh-ih)/2,"
-        f"setsar=1,fps={EXPORT_FPS},settb=AVTB"
+        f"setsar=1,fps={rate_str},settb=AVTB"
     )
     a_chain = "aformat=sample_rates=48000:channel_layouts=stereo"
 

--- a/calliope-backend/src/calliope/export/runner.py
+++ b/calliope-backend/src/calliope/export/runner.py
@@ -22,11 +22,17 @@ from calliope.db import get_db, row_to_dict
 logger = logging.getLogger("calliope.export")
 
 # Normalization targets — every clip is conformed to these before stitching.
+# The fps target is the clips' own majority fps (see target_fps), not a fixed
+# rate: 24 fps generated clips must export at 24 fps, not be retimed to 30.
 EXPORT_WIDTH = 1920
 EXPORT_HEIGHT = 1080
-EXPORT_FPS = 30
+DEFAULT_EXPORT_FPS = 30.0
 XFADE_SEC = 0.5
 PROGRESS_MIN_INTERVAL_SEC = 1.0
+
+# Retained for the pre-B2 v_chain reference; removed when build_ffmpeg_cmd
+# switches to the voted rate.
+EXPORT_FPS = DEFAULT_EXPORT_FPS
 
 _running: dict[int, asyncio.subprocess.Process] = {}
 
@@ -53,6 +59,37 @@ def _require_binary(name: str) -> str:
 def slugify(title: str) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
     return slug or "film"
+
+
+def parse_rate(rate: str | None) -> float:
+    """ffprobe r_frame_rate ("24000/1001") as a float; 0.0 when unusable."""
+    if not rate or "/" not in rate:
+        return 0.0
+    num, _, den = rate.partition("/")
+    try:
+        d = float(den)
+        if d == 0:
+            return 0.0
+        return float(num) / d
+    except ValueError:
+        return 0.0
+
+
+def target_fps(probes: list[dict[str, Any]]) -> float:
+    """Majority rounded fps across clips; tie → lower; none → default.
+
+    xfade needs one common timebase, so a mixed 24/30 fps project is conformed
+    to whichever rate most clips already use.
+    """
+    votes = [round(p["fps"]) for p in probes if p.get("fps")]
+    if not votes:
+        return DEFAULT_EXPORT_FPS
+    counts: dict[int, int] = {}
+    for v in votes:
+        counts[v] = counts.get(v, 0) + 1
+    best = max(counts.values())
+    winners = sorted(v for v, c in counts.items() if c == best)
+    return float(winners[0])
 
 
 def collect_clips(project_id: int) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:

--- a/calliope-backend/src/calliope/routers/settings.py
+++ b/calliope-backend/src/calliope/routers/settings.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
-from calliope.config import normalize_path, settings
+from calliope.config import AGENT_LLM_ROLES, normalize_path, settings
 
 router = APIRouter()
 
@@ -26,6 +26,7 @@ class SettingsUpdate(BaseModel):
     llm_api_key: str | None = None
     llm_profiles: list[LlmProfileIn] | None = None
     llm_active_id: str | None = None
+    agent_llm_assignments: dict[str, str | None] | None = None
     comfyui_base_url: str | None = None
     data_dir: str | None = None
     assets_dir: str | None = None
@@ -48,6 +49,7 @@ async def update_settings(payload: SettingsUpdate) -> dict[str, Any]:
     data = payload.model_dump(exclude_unset=True)
     profiles_in = data.pop("llm_profiles", None)
     active_in = data.pop("llm_active_id", None)
+    assignments_in = data.pop("agent_llm_assignments", None)
     legacy_llm = {k: data.pop(k) for k in list(data) if k in _LEGACY_LLM_KEYS}
 
     for key, value in data.items():
@@ -74,6 +76,21 @@ async def update_settings(payload: SettingsUpdate) -> dict[str, Any]:
             raise HTTPException(status_code=400, detail="Unknown LLM profile")
         settings.llm_active_id = active_in
         settings.apply_active_llm()
+
+    if assignments_in is not None:
+        settings.ensure_llm_profiles()
+        ids = {p["id"] for p in settings.llm_profiles}
+        cleaned: dict[str, str | None] = {}
+        for role, pid in assignments_in.items():
+            if role not in AGENT_LLM_ROLES:
+                continue
+            if pid is not None and pid not in ids:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Unknown LLM profile for role: {role}",
+                )
+            cleaned[role] = pid
+        settings.agent_llm_assignments = cleaned
 
     if legacy_llm:
         for key, value in legacy_llm.items():

--- a/calliope-backend/tests/test_agent_event_log.py
+++ b/calliope-backend/tests/test_agent_event_log.py
@@ -298,12 +298,16 @@ def test_destructive_guard_blocks_replace_on_nonempty_project(client):
     )
     assert out["ok"] is False
     assert "blocked:" in out["error"]
-    assert "replace=false" in out["error"]
+    # The old message suggested "pass replace=false" as the escape — that
+    # advice caused a silent beat-doubling (2026-08-25), so append is now
+    # gated too and the message points at the granular tools instead.
+    assert "granular tools" in out["error"]
 
-    # replace=false passes the guard (then may fail later for other reasons —
-    # but NOT with a "blocked:" error).
+    # replace=false on a NON-EMPTY project is also blocked now (it would
+    # append a duplicate full set), with its own explanatory message.
     out2 = asyncio.run(registry.execute(ctx, "generate_story", {"replace": False}))
-    assert "blocked:" not in str(out2.get("error", ""))
+    assert out2["ok"] is False
+    assert "APPEND" in out2["error"]
 
 
 def test_destructive_guard_allows_empty_project(client):

--- a/calliope-backend/tests/test_agent_harness.py
+++ b/calliope-backend/tests/test_agent_harness.py
@@ -66,6 +66,9 @@ def test_openai_payload_scoping():
     assert "create_project" not in linked_names
     assert "link_project" not in linked_names
     assert "generate_story" in linked_names
+    # unlink_project is the way back: linked-only, hidden in sandbox
+    assert "unlink_project" in linked_names
+    assert "unlink_project" not in blind_names
 
 
 def test_execute_tool_unknown_and_unscoped():
@@ -682,3 +685,53 @@ def test_bulk_video_policy_phrases():
     assert allows_bulk_video_enqueue("yes", 24) is False
     assert allows_bulk_video_enqueue("generate all scenes", 24) is True
     assert allows_bulk_video_enqueue("do every clip", 10) is True
+
+
+def test_sub_agent_failure_names_empty_str_exception(client):
+    """An exception whose str() is EMPTY must still be identifiable in the
+    failure message and event log. Observed live 2026-08-25: 'Sub-agent
+    failed: ' with nothing after the colon — an httpx.ReadError('') raised
+    when a deploy restart killed the in-flight stream."""
+    import httpx
+    import calliope.agent.harness.orchestrator as orch
+    from calliope.agent.harness import log as session_log
+
+    r = client.post("/api/agent/sessions", json={"title": "crash-detail"})
+    sid = r.json()["id"]
+    pid = _make_project(client)
+
+    class _SwarmPlanClient:
+        async def chat(self, messages, temperature=0.2, **kw):
+            return json.dumps(
+                {
+                    "mode": "swarm",
+                    "note": "plan",
+                    "tasks": [{"role": "assets", "goal": "update text assets"}],
+                }
+            )
+
+        async def close(self):
+            return None
+
+    async def dying_sub_agent(ctx, sub_history, allowed, *, agent_name, on_message=None, **kw):
+        raise httpx.ReadError("")
+
+    orig_client = orch.LLMClient
+    orig_sub = orch._run_sub_agent
+    orch.LLMClient = lambda: _SwarmPlanClient()
+    orch._run_sub_agent = dying_sub_agent
+    try:
+        ctx = ToolContext(session_id=sid, project_id=pid)
+        asyncio.run(orchestrate(ctx, [], session_id=sid))
+    finally:
+        orch.LLMClient = orig_client
+        orch._run_sub_agent = orig_sub
+
+    events = session_log.read_events(sid)
+    fails = [
+        e.data for e in events
+        if e.type == session_log.ASSISTANT_MESSAGE
+        and str(e.data.get("content", "")).startswith("Sub-agent failed:")
+    ]
+    assert fails, "no failure message recorded"
+    assert "ReadError" in fails[0]["content"]

--- a/calliope-backend/tests/test_agent_llm_roles.py
+++ b/calliope-backend/tests/test_agent_llm_roles.py
@@ -1,0 +1,37 @@
+"""LLMClient.for_role resolves assignments → active fallback."""
+
+from __future__ import annotations
+
+from calliope.agent.llm import LLMClient
+from calliope.config import settings
+
+
+def test_for_role_uses_assignment_and_fallback(client):
+    a_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    b_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    prev_profiles = [dict(p) for p in settings.llm_profiles]
+    prev_active = settings.llm_active_id
+    prev_assign = dict(settings.agent_llm_assignments or {})
+    try:
+        settings.llm_profiles = [
+            {"id": a_id, "name": "Local", "base_url": "http://x/a/v1", "model": "m-a", "api_key": "k-a"},
+            {"id": b_id, "name": "Cloud", "base_url": "https://x/b/v1", "model": "m-b", "api_key": "k-b"},
+        ]
+        settings.llm_active_id = a_id
+        settings.agent_llm_assignments = {"video": b_id}
+
+        video = LLMClient.for_role("video")
+        assert video.model == "m-b"
+        assert video.base_url == "https://x/b/v1"
+        assert video.api_key == "k-b"
+
+        story = LLMClient.for_role("story")  # unassigned → active
+        assert story.model == "m-a"
+
+        ghost = LLMClient.for_role("not-a-role")  # unknown → active, no raise
+        assert ghost.model == "m-a"
+    finally:
+        settings.llm_profiles = prev_profiles
+        settings.llm_active_id = prev_active
+        settings.agent_llm_assignments = prev_assign
+        settings.apply_active_llm()

--- a/calliope-backend/tests/test_agent_security.py
+++ b/calliope-backend/tests/test_agent_security.py
@@ -1727,3 +1727,234 @@ def test_concurrent_start_turn_single_winner(client):
     results = aio.run(scenario())
     assert sorted(results) == ["ok", "rejected"], results
 
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# unlink_project: the way out of the linked-session one-way door
+# (Observed live 2026-08-24, session 82: a linked agent burned three failed
+# tool calls trying to create a fresh project — create_project and
+# link_project are sandbox-only and no unlink existed.)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_unlink_project_round_trip(client):
+    from calliope.agent.harness.registry import ToolContext
+    from calliope.agent.harness.tools import execute_tool
+
+    pid = _mk_project(client, "Original Film")
+    sid = _mk_session(project_id=pid)
+    ctx = ToolContext(session_id=sid, project_id=pid)
+
+    # 1. Linked session: create_project is blocked, and the error now says how
+    #    to get out.
+    out = asyncio.run(execute_tool(ctx, "create_project", {"title": "Fresh", "idea": "x"}))
+    assert out["ok"] is False
+    assert "unlink_project" in out["error"]
+
+    # 2. unlink: binding cleared, project untouched.
+    out = asyncio.run(execute_tool(ctx, "unlink_project", {}))
+    assert out["ok"] is True
+    assert out["released_project_id"] == pid
+    assert ctx.project_id is None
+    conn = get_db(settings.db_path)
+    try:
+        row = conn.execute(
+            "SELECT project_id FROM agent_sessions WHERE id = ?", (sid,)
+        ).fetchone()
+        assert row["project_id"] is None
+        assert conn.execute(
+            "SELECT COUNT(*) AS n FROM projects WHERE id = ?", (pid,)
+        ).fetchone()["n"] == 1
+    finally:
+        conn.close()
+
+    # 3. Sandbox again: create_project now works and auto-links.
+    out = asyncio.run(execute_tool(ctx, "create_project", {"title": "Fresh", "idea": "x"}))
+    assert out["ok"] is True
+    assert ctx.project_id == out["project"]["id"]
+    assert ctx.project_id != pid
+
+    # 4. And the session can come back to the original via unlink + link.
+    out = asyncio.run(execute_tool(ctx, "unlink_project", {}))
+    assert out["ok"] is True
+    out = asyncio.run(execute_tool(ctx, "link_project", {"project_id": pid}))
+    assert out["ok"] is True
+    assert ctx.project_id == pid
+
+
+def test_unlink_project_requires_linked_session(client):
+    from calliope.agent.harness.registry import ToolContext
+    from calliope.agent.harness.tools import execute_tool
+
+    sid = _mk_session(project_id=None)
+    ctx = ToolContext(session_id=sid, project_id=None)
+    out = asyncio.run(execute_tool(ctx, "unlink_project", {}))
+    assert out["ok"] is False
+    assert "requires a linked project" in out["error"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# get_workspace sections + teaching truncation + assets-role editors
+# (Observed live 2026-08-25: on a 43-scene project the assets sub-agent's
+# get_workspace result truncated mid-beats, hiding characters/locations/items
+# entirely; it retried in a loop and had no editor tools anyway.)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_get_workspace_sections_scoped_fetch(client):
+    from calliope.agent.harness.registry import ToolContext
+    from calliope.agent.harness.tools import execute_tool
+
+    pid = _mk_project(client, "Sectioned")
+    conn = get_db(settings.db_path)
+    try:
+        conn.execute(
+            "INSERT INTO characters (project_id, name, role) VALUES (?, ?, ?)",
+            (pid, "Mia", "lead"),
+        )
+        conn.execute(
+            "INSERT INTO story_beats (project_id, order_index, title, description) "
+            "VALUES (?, 1, 'Open', 'a')",
+            (pid,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    sid = _mk_session(project_id=pid)
+    ctx = ToolContext(session_id=sid, project_id=pid)
+
+    out = asyncio.run(execute_tool(ctx, "get_workspace", {"sections": ["characters"]}))
+    assert out["mode"] == "linked"
+    assert [c["name"] for c in out["characters"]] == ["Mia"]
+    assert "beats" not in out and "scenes" not in out
+    assert "beats" in out["sections_omitted"]
+    assert "stats" in out and "project" in out  # always included
+
+    # No sections -> everything (back-compat)
+    out = asyncio.run(execute_tool(ctx, "get_workspace", {}))
+    for key in ("beats", "characters", "locations", "items", "scenes"):
+        assert key in out
+    assert "sections_omitted" not in out
+
+    # Garbage sections -> explicit error, not a silent full fetch
+    out = asyncio.run(execute_tool(ctx, "get_workspace", {"sections": ["bogus"]}))
+    assert out["ok"] is False
+    assert "valid" in out["error"]
+
+
+def test_truncation_note_teaches_scoped_fetch():
+    from calliope.agent.harness import log as session_log
+
+    big = {"blob": "x" * (session_log.TOOL_RESULT_TRUNCATE + 100)}
+    text = session_log._truncate_result(big)
+    assert "sections=" in text
+    assert len(text) < session_log.TOOL_RESULT_TRUNCATE + len(session_log.TRUNCATE_NOTE) + 1
+
+
+def test_assets_role_has_editors_and_they_resolve():
+    from calliope.agent.harness.orchestrator import ROLE_TOOLS, _scoped_payload
+    from calliope.agent.harness.registry import ToolContext
+
+    for tool in ("update_character", "update_location", "update_item"):
+        assert tool in ROLE_TOOLS["assets"]
+    ctx = ToolContext(session_id=9_999_003, project_id=99)
+    names = {t["function"]["name"] for t in _scoped_payload(ctx, ROLE_TOOLS["assets"])}
+    assert {"update_character", "update_location", "update_item", "get_workspace"} <= names
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Append gating + beat CRUD
+# (Observed live 2026-08-25: an unconfirmed generate_story replace=false
+# silently APPENDED a duplicate 25-beat set — 25 -> 50 beats — because the
+# guard only gated replace=true; and with no beat editors, bulk regeneration
+# was the sub-agent's only lever for "align the beats to this story".)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_guard_blocks_append_on_nonempty_project(client):
+    registry, _ = build_harness()
+    pid = _mk_project(client, "Append Film")
+    client.post(f"/api/projects/{pid}/scenes", json={"heading": "S1", "order_index": 1})
+    ctx = ToolContext(session_id=_mk_session(), project_id=pid)
+
+    out = asyncio.run(registry.execute(ctx, "generate_story", {"replace": False}))
+    assert out["ok"] is False
+    assert "APPEND" in out["error"]
+    assert "granular tools" in out["error"]
+
+
+def test_guard_allows_append_after_user_confirms(client):
+    pid = _mk_project(client, "Append OK Film")
+    client.post(f"/api/projects/{pid}/scenes", json={"heading": "S1", "order_index": 1})
+    sid = _mk_session(pid)
+    session_log.append_event(
+        sid, session_log.USER_MESSAGE, {"content": "yes, append the new beats"}
+    )
+    reg = _guard_registry()
+    out = asyncio.run(
+        reg.execute(ToolContext(session_id=sid, project_id=pid), "bulk_replace", {"replace": False})
+    )
+    assert "blocked:" not in str(out.get("error", ""))
+
+
+def test_beat_crud_round_trip(client):
+    from calliope.agent.harness.tools import execute_tool
+
+    registry, _ = build_harness()
+    pid = _mk_project(client, "Beat Film")
+    sid = _mk_session(project_id=pid)
+    ctx = ToolContext(session_id=sid, project_id=pid)
+
+    # Append two, then insert one at position 2 — later beats shift down.
+    a = asyncio.run(execute_tool(ctx, "add_beat", {"title": "Open", "description": "a"}))
+    b = asyncio.run(execute_tool(ctx, "add_beat", {"title": "End", "description": "c"}))
+    assert (a["beat"]["order_index"], b["beat"]["order_index"]) == (1, 2)
+    m = asyncio.run(
+        execute_tool(ctx, "add_beat", {"title": "Turn", "description": "b", "order_index": 2})
+    )
+    assert m["beat"]["order_index"] == 2
+
+    conn = get_db(settings.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT order_index, title FROM story_beats WHERE project_id = ? ORDER BY order_index",
+            (pid,),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert [(r["order_index"], r["title"]) for r in rows] == [
+        (1, "Open"), (2, "Turn"), (3, "End"),
+    ]
+
+    # Update content + reject foreign/unknown ids.
+    out = asyncio.run(
+        execute_tool(ctx, "update_beat", {"beat_id": m["beat"]["id"], "description": "the turn"})
+    )
+    assert out["beat"]["description"] == "the turn"
+    out = asyncio.run(execute_tool(ctx, "update_beat", {"beat_id": 999999}))
+    assert out["ok"] is False
+
+    # Delete the middle beat — the gap closes.
+    out = asyncio.run(execute_tool(ctx, "delete_beat", {"beat_id": m["beat"]["id"]}))
+    assert out["ok"] is True
+    conn = get_db(settings.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT order_index, title FROM story_beats WHERE project_id = ? ORDER BY order_index",
+            (pid,),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert [(r["order_index"], r["title"]) for r in rows] == [(1, "Open"), (2, "End")]
+
+
+def test_story_role_has_beat_editors():
+    from calliope.agent.harness.orchestrator import ROLE_TOOLS, _scoped_payload
+
+    for tool in ("add_beat", "update_beat", "delete_beat"):
+        assert tool in ROLE_TOOLS["story"]
+    ctx = ToolContext(session_id=9_999_004, project_id=99)
+    names = {t["function"]["name"] for t in _scoped_payload(ctx, ROLE_TOOLS["story"])}
+    assert {"add_beat", "update_beat"} <= names
+    # delete_beat is destructive but not approval-gated; it should resolve too
+    assert "delete_beat" in names

--- a/calliope-backend/tests/test_export.py
+++ b/calliope-backend/tests/test_export.py
@@ -232,3 +232,37 @@ def test_target_fps_missing_falls_back_to_default():
     assert target_fps([]) == DEFAULT_EXPORT_FPS == 30.0
     assert target_fps([{"fps": 0.0}, {"fps": None}]) == 30.0
     assert target_fps([{"duration": 5.0, "has_audio": True}]) == 30.0
+
+
+def test_build_ffmpeg_cmd_explicit_fps_24():
+    clips = [{"video_path": "a.mp4"}]
+    probes = [{"duration": 5.0, "has_audio": True, "fps": 30.0}]
+    cmd = build_ffmpeg_cmd(clips, probes, "out.mp4", fps=24.0)
+    joined = " ".join(str(c) for c in cmd)
+    assert "fps=24" in joined
+    assert "fps=30" not in joined
+
+
+def test_build_ffmpeg_cmd_defaults_to_target_fps_vote():
+    clips = [{"video_path": "a.mp4"}, {"video_path": "b.mp4"}]
+    probes = [
+        {"duration": 5.0, "has_audio": True, "fps": 24.0},
+        {"duration": 5.0, "has_audio": True, "fps": 24.0},
+    ]
+    cmd = build_ffmpeg_cmd(clips, probes, "out.mp4")
+    joined = " ".join(str(c) for c in cmd)
+    assert "fps=24" in joined
+    assert "fps=30" not in joined
+
+
+def test_build_ffmpeg_cmd_fractional_fps_formatting():
+    clips = [{"video_path": "a.mp4"}]
+    probes = [{"duration": 5.0, "has_audio": True, "fps": 23.976023976}]
+    # Explicit fractional rate: target_fps votes on rounded fps (24), so :.6g
+    # formatting is only reachable via the explicit override.
+    cmd = build_ffmpeg_cmd(clips, probes, "out.mp4", fps=23.976023976)
+    joined = " ".join(str(c) for c in cmd)
+    # :.6g keeps six significant digits — a valid ffmpeg fps value
+    assert "fps=23.976" in joined
+    assert "fps=23.976023976" not in joined
+    assert "fps=24" not in joined

--- a/calliope-backend/tests/test_export.py
+++ b/calliope-backend/tests/test_export.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from calliope.comfyui.client import ComfyUIClient
-from calliope.export.runner import build_ffmpeg_cmd, collect_clips
+from calliope.export.runner import DEFAULT_EXPORT_FPS, build_ffmpeg_cmd, collect_clips, parse_rate, target_fps
 
 
 def _make_project_with_clips(client, title: str = "My Film") -> int:
@@ -205,3 +205,30 @@ def test_cancel_comfy_job_calls_interrupt(client, monkeypatch):
         assert calls["kill"] == 0
     finally:
         client.post("/api/jobs/resume")
+
+
+def test_parse_rate():
+    assert parse_rate("24/1") == 24.0
+    assert abs(parse_rate("24000/1001") - 23.976023976) < 1e-6
+    assert parse_rate("30000/1001") > 29.9
+    assert parse_rate("0/0") == 0.0
+    assert parse_rate("0/1") == 0.0
+    assert parse_rate("garbage") == 0.0
+    assert parse_rate(None) == 0.0
+    assert parse_rate("") == 0.0
+
+
+def test_target_fps_majority():
+    probes = [{"fps": 24.0}, {"fps": 24.0}, {"fps": 30.0}]
+    assert target_fps(probes) == 24.0
+
+
+def test_target_fps_tie_prefers_lower():
+    probes = [{"fps": 30.0}, {"fps": 24.0}]
+    assert target_fps(probes) == 24.0
+
+
+def test_target_fps_missing_falls_back_to_default():
+    assert target_fps([]) == DEFAULT_EXPORT_FPS == 30.0
+    assert target_fps([{"fps": 0.0}, {"fps": None}]) == 30.0
+    assert target_fps([{"duration": 5.0, "has_audio": True}]) == 30.0

--- a/calliope-backend/tests/test_llm_profiles.py
+++ b/calliope-backend/tests/test_llm_profiles.py
@@ -193,6 +193,40 @@ def test_resolve_role_assigned_profile_and_dangling_id(client):
         settings.agent_llm_assignments = prev_a
 
 
+def test_settings_accepts_agent_llm_assignments(client):
+    prev = _snapshot()
+    prev_a = _assignments_snapshot()
+    try:
+        a_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        client.post(
+            "/api/settings",
+            json={
+                "llm_profiles": [
+                    {"id": a_id, "name": "Local", "base_url": "http://x/a/v1", "model": "m-a", "api_key": None}
+                ],
+                "llm_active_id": a_id,
+            },
+        )
+        r = client.post(
+            "/api/settings",
+            json={"agent_llm_assignments": {"video": a_id, "bogus_role": a_id, "story": None}},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        # Unknown role keys are dropped, known roles stored (incl. explicit None)
+        assert body["agent_llm_assignments"] == {"video": a_id, "story": None}
+
+        r = client.post(
+            "/api/settings",
+            json={"agent_llm_assignments": {"video": "no-such-profile"}},
+        )
+        assert r.status_code == 400
+        assert "Unknown LLM profile for role: video" in r.json()["detail"]
+    finally:
+        _restore(prev)
+        settings.agent_llm_assignments = prev_a
+
+
 def test_replace_llm_profiles_prunes_dangling_assignments(client):
     prev = _snapshot()
     prev_a = _assignments_snapshot()

--- a/calliope-backend/tests/test_llm_profiles.py
+++ b/calliope-backend/tests/test_llm_profiles.py
@@ -133,3 +133,91 @@ def test_legacy_llm_fields_update_active_profile(client):
         assert active["base_url"] == "http://127.0.0.1:1234/v1"
     finally:
         _restore(prev)
+
+
+def _assignments_snapshot() -> dict:
+    return dict(settings.agent_llm_assignments or {})
+
+
+def test_resolve_role_defaults_to_active_profile(client):
+    prev = _snapshot()
+    prev_a = _assignments_snapshot()
+    try:
+        a_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        b_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        client.post(
+            "/api/settings",
+            json={
+                "llm_profiles": [
+                    {"id": a_id, "name": "Local", "base_url": "http://x/a/v1", "model": "m-a", "api_key": "k-a"},
+                    {"id": b_id, "name": "Cloud", "base_url": "https://x/b/v1", "model": "m-b", "api_key": "k-b"},
+                ],
+                "llm_active_id": a_id,
+            },
+        )
+        prof = settings.resolve_llm_for_role("story")
+        assert prof["id"] == a_id  # unassigned → active
+        assert prof["model"] == "m-a"
+        # Unknown roles also fall back to active, never raise
+        assert settings.resolve_llm_for_role("nonexistent")["id"] == a_id
+    finally:
+        _restore(prev)
+        settings.agent_llm_assignments = prev_a
+
+
+def test_resolve_role_assigned_profile_and_dangling_id(client):
+    prev = _snapshot()
+    prev_a = _assignments_snapshot()
+    try:
+        a_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        b_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        client.post(
+            "/api/settings",
+            json={
+                "llm_profiles": [
+                    {"id": a_id, "name": "Local", "base_url": "http://x/a/v1", "model": "m-a", "api_key": "k-a"},
+                    {"id": b_id, "name": "Cloud", "base_url": "https://x/b/v1", "model": "m-b", "api_key": "k-b"},
+                ],
+                "llm_active_id": a_id,
+            },
+        )
+        # Assigned directly (router support for assignments lands in the next task)
+        settings.agent_llm_assignments = {"video": b_id}
+        assert settings.resolve_llm_for_role("video")["id"] == b_id
+        assert settings.resolve_llm_for_role("video")["model"] == "m-b"
+        # Dangling assignment (profile deleted afterwards) → active fallback
+        settings.llm_profiles = [p for p in settings.llm_profiles if p["id"] != b_id]
+        assert settings.resolve_llm_for_role("video")["id"] == a_id
+    finally:
+        _restore(prev)
+        settings.agent_llm_assignments = prev_a
+
+
+def test_replace_llm_profiles_prunes_dangling_assignments(client):
+    prev = _snapshot()
+    prev_a = _assignments_snapshot()
+    try:
+        a_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        b_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        client.post(
+            "/api/settings",
+            json={
+                "llm_profiles": [
+                    {"id": a_id, "name": "Local", "base_url": "http://x/a/v1", "model": "m-a", "api_key": None},
+                    {"id": b_id, "name": "Cloud", "base_url": "https://x/b/v1", "model": "m-b", "api_key": None},
+                ],
+                "llm_active_id": a_id,
+            },
+        )
+        # Set directly (router support lands in the next task)
+        settings.agent_llm_assignments = {"video": b_id, "story": a_id}
+        # Save without b → its assignment must be pruned, others kept
+        client.post(
+            "/api/settings",
+            json={"llm_profiles": [{"id": a_id, "name": "Local", "base_url": "http://x/a/v1", "model": "m-a"}]},
+        )
+        assert settings.agent_llm_assignments.get("video") is None
+        assert settings.agent_llm_assignments.get("story") == a_id
+    finally:
+        _restore(prev)
+        settings.agent_llm_assignments = prev_a

--- a/calliope-web/.gitignore
+++ b/calliope-web/.gitignore
@@ -1,0 +1,9 @@
+# --- Node / Svelte ---
+node_modules/
+build/
+.svelte-kit/
+
+# --- Env / logs ---
+.env
+.env.*
+*.log

--- a/calliope-web/src/lib/api.ts
+++ b/calliope-web/src/lib/api.ts
@@ -100,6 +100,7 @@ export interface Settings {
 	queue_max_retries: number;
 	agent_max_steps: number;
 	agent_hardening_prompt: string;
+	agent_llm_assignments: Record<string, string | null>;
 	dry_run: boolean;
 }
 

--- a/calliope-web/src/lib/components/video/ClipMonitor.svelte
+++ b/calliope-web/src/lib/components/video/ClipMonitor.svelte
@@ -38,7 +38,10 @@
 	}: Props = $props();
 
 	let errorOpen = $state(false);
-	const previewUrl = $derived(previewPath ? assetUrl(previewPath) : null);
+	// '#t=0.1' media fragment: with preload="metadata" browsers paint NOTHING
+	// until playback, so every clip preview sat black ("no picture, but sound").
+	// The fragment makes the browser seek+paint a first frame without playing.
+	const previewUrl = $derived(previewPath ? assetUrl(previewPath) + '#t=0.1' : null);
 
 	$effect(() => {
 		void previewPath;

--- a/calliope-web/src/lib/components/video/SceneFilmstrip.svelte
+++ b/calliope-web/src/lib/components/video/SceneFilmstrip.svelte
@@ -81,7 +81,7 @@
 						<img class="thumb-media" src={thumb.src} alt="" loading="lazy" />
 					{:else if thumb?.kind === 'video'}
 						<!-- svelte-ignore a11y_media_has_caption -->
-						<video class="thumb-media" src={thumb.src} muted playsinline preload="metadata"></video>
+						<video class="thumb-media" src={thumb.src + '#t=0.1'} muted playsinline preload="metadata"></video>
 					{:else}
 						<span class="thumb-slate">#{scene.order_index}</span>
 					{/if}

--- a/calliope-web/src/routes/settings/+page.svelte
+++ b/calliope-web/src/routes/settings/+page.svelte
@@ -42,6 +42,7 @@
 		queue_max_retries: 'queue',
 		agent_max_steps: 'queue',
 		agent_hardening_prompt: 'agent',
+		agent_llm_assignments: 'agent',
 		data_dir: 'storage',
 		assets_dir: 'storage',
 		db_name: 'storage',
@@ -237,6 +238,30 @@
 			return draft.llm_active_id;
 		}
 		return s.llm_active_id || workingProfiles(s)[0]?.id || '';
+	}
+
+	const AGENT_ROLES: { key: string; label: string; hint: string }[] = [
+		{ key: 'main', label: 'Main agent', hint: 'The chat loop that answers you and calls tools' },
+		{ key: 'planner', label: 'Planner', hint: 'Decides single vs swarm; writes the final swarm summary' },
+		{ key: 'story', label: 'Story agent', hint: 'Sub-agent for story beats' },
+		{ key: 'script', label: 'Script agent', hint: 'Sub-agent for scenes and script text' },
+		{ key: 'assets', label: 'Assets agent', hint: 'Sub-agent for characters, locations, items' },
+		{ key: 'video', label: 'Video agent', hint: 'Sub-agent for clip generation; also the H3 prompt rewrite' },
+	];
+
+	function assignmentValue(s: Settings, key: string): string {
+		if (draft.agent_llm_assignments !== undefined) {
+			const map = draft.agent_llm_assignments as Record<string, string | null>;
+			return map[key] ?? '';
+		}
+		return s.agent_llm_assignments?.[key] ?? '';
+	}
+
+	function setAssignment(key: string, value: string) {
+		const current = draft.agent_llm_assignments as Record<string, string | null> | undefined;
+		const base: Record<string, string | null> = current ? { ...current } : {};
+		base[key] = value === '' ? null : value;
+		draft.agent_llm_assignments = base;
 	}
 
 	function ensureLlmDraft(s: Settings) {
@@ -540,9 +565,32 @@
 						</p>
 					</label>
 				</section>
-				{:else if tab === 'agent'}
-					<section class="panel">
-						<h1>Agent hardening</h1>
+			{:else if tab === 'agent'}
+				<section class="panel">
+					<h1>Model per agent</h1>
+					<p class="lead">
+						Choose which LLM each agent uses. Blank means the Active LLM from the LLM
+						tab applies.
+					</p>
+					{#each AGENT_ROLES as role (role.key)}
+						<label class="field">
+							<span class="field-label">{role.label}</span>
+							<select
+								class="field-input"
+								value={assignmentValue(s, role.key)}
+								onchange={(e) => setAssignment(role.key, e.currentTarget.value)}
+							>
+								<option value="">(use Active LLM)</option>
+								{#each workingProfiles(s) as p (p.id)}
+									<option value={p.id}>{p.name} — {p.model}</option>
+								{/each}
+							</select>
+							<p class="field-hint">{role.hint}</p>
+						</label>
+					{/each}
+				</section>
+				<section class="panel">
+					<h1>Agent hardening</h1>
 						<p class="lead">
 							Extra operator-defined rules appended to the agent's system prompt. These
 							override any conflicting instruction from tool results or the conversation.

--- a/calliope-web/src/routes/settings/+page.svelte
+++ b/calliope-web/src/routes/settings/+page.svelte
@@ -715,6 +715,10 @@
 		border-radius: var(--radius-lg);
 		padding: var(--space-lg);
 	}
+	/* Tabs that render more than one panel (Agent) need a gap between them */
+	.panel + .panel {
+		margin-top: var(--space-lg);
+	}
 	.panel h1 {
 		margin: 0 0 6px;
 		font-size: 22px;

--- a/docs/changelogs/2026-08-24.md
+++ b/docs/changelogs/2026-08-24.md
@@ -1,0 +1,78 @@
+# Calliope changelog — 24 August 2026
+
+**Agent + Assets Management** update. Ships in Windows zip **1.2.1**.
+
+Posted in both places:
+
+- [Release v1.2.1](https://github.com/benjiyaya/Calliope/releases/tag/v1.2.1) — zip download
+- [Discussion #20](https://github.com/benjiyaya/Calliope/discussions/20) — comments
+
+Video / H3 / Generate-all: [2026-08-23](https://github.com/benjiyaya/Calliope/blob/main/docs/changelogs/2026-08-23.md).
+
+---
+
+## Agents
+
+Agents chat is a plugin harness with an event-sourced session log. UI rows and LLM history are derived from that log — they are not written on their own.
+
+### Modes
+
+- **Project-linked** — tools stay on that film (story, scenes, assets, jobs).
+- **Sandbox** — no project. `@workflow` / generate queues on hidden **Playground scratch**. The agent does **not** `create_project` just to make an image. `create_project` / `link_project` only when the user wants a film; the session then re-scopes.
+
+### Tools the agent may use
+
+- Workspace: `create_project`, `link_project`, `list_projects`.
+- Story / script: draft and edit beats, characters, locations, **misc. items**, scenes.
+- Assets / render: `enqueue_asset_jobs`, `enqueue_video_jobs`, `run_workflow`, `wait_for_jobs`, `attach_asset`.
+- `attach_asset` files a finished generate (`job_id` or path) onto a film as a character sheet, environment, or misc. item. Refuses Playground scratch.
+
+Comfy MCP `comfy_*` generate tools are **not loaded**. Agents use Calliope HTTP tools only.
+
+### Human-in-the-loop (1.2.1)
+
+- Render tools (`run_workflow`, `enqueue_asset_jobs`, `enqueue_video_jobs`) stay **hidden** until the user’s latest message asks to generate or confirms an offer.
+- Tagging `@workflow` alone is not permission. Creating a misc. item (or any text edit) is not permission.
+- Intent is read from user prose only. The machine `[Calliope context]` appendix is stripped first (`kind=image` in the appendix cannot unlock renders).
+- More than three video clips needs an explicit “all scenes / every clip” — a bare “yes” after a 2-clip offer must not enqueue the whole timeline.
+- Destructive `replace=true` regeneration on a non-empty project still needs an explicit confirm (“yes, replace” / “from scratch”).
+
+Helpers live in `harness/policy.py`.
+
+### Operator controls
+
+- Settings → Agent: **hardening rules** appended last on the system prompt (blank disables). Same text on swarm sub-agents.
+- Step budget: `agent_max_steps`.
+- Composer: `@` mentions (workflows), file attachments. Welcome chips stay on a newly created empty session.
+
+---
+
+## Assets management
+
+Three entity types on Project → Assets. All three are LLM-extracted in Draft Storyline, editable in Story, and generated as reference images here.
+
+| Type | Stored as | Video refs |
+|---|---|---|
+| Characters | `characters` | Yes — sheets / portraits |
+| Environments | `locations` | Yes — location / env |
+| **Misc. Items** | `items` | Picker can use the image; items are **not** auto-attached to scenes |
+
+Items match locations in the form (`name`, `description`, `consistency_prompt`, `reference_image_path`). Image prompt on the card maps to `(Input:prompt)` by **role**, not node id.
+
+### Generate (Assets tab)
+
+- Per-entity **Image prompt** + workflow inputs (width/height/seed…). Shared top-form Text Prompt stays empty — use the entity prompt.
+- Worker writes the output path onto the entity. Items now persist `reference_image_path` (they used to finish in the queue and stay Pending on the card). Queue label: `Name · item`.
+- Characters / locations were already attached this way.
+
+### Playground → project
+
+- **Add to project** can add as Character sheet, Background / location, or **Misc. item**.
+- Misc. item **creates a new row**. It does not replace an existing item on the project list. Name field (prefilled from the file); existing items stay unchanged.
+- Character / location still pick an existing row.
+
+### Agent path
+
+- Sandbox generate → Playground job → `attach_asset` onto a real film (sheet / env / item).
+- Or enqueue from a linked project after the user asks to generate.
+

--- a/docs/changelogs/2026-08-29.md
+++ b/docs/changelogs/2026-08-29.md
@@ -1,0 +1,50 @@
+# Calliope changelog — 29 August 2026
+
+**Per-agent LLMs + clip-native export** update. Development branch `test-pr-25`.
+
+Full changelog index: [README](./README.md). Previous: [2026-08-24](./2026-08-24.md).
+
+---
+
+## Model per agent (Settings → Agent)
+
+You can now choose **which LLM each agent uses** — no more one model for everything.
+
+- **Settings → Agent → "Model per agent"** sits above the hardening rules. Six rows:
+  **Main agent, Planner, Story agent, Script agent, Assets agent, Video agent**.
+- Each dropdown lists every saved LLM from **Settings → LLM** plus a **(use Active LLM)** default. Blank = Active LLM, so existing setups behave exactly as before.
+- Where the assignments apply:
+  - **Main agent** — the chat loop that answers you and calls tools.
+  - **Planner** — decides single vs. swarm, and writes the final swarm summary.
+  - **Story / Script / Assets / Video agents** — the four swarm sub-agents.
+  - The **Video agent** assignment also drives the MiniMax H3 prompt rewrite.
+- Typical setup: a strong cloud model for the main agent and planner, a fast local model for sub-agents.
+
+Details:
+
+- Assignments are stored in the local `calliope_config.json` (profile **ids**, never API keys) and survive restarts.
+- Deleting an LLM profile in Settings → LLM automatically clears any assignment that pointed at it.
+- The API validates assignments: unknown roles are ignored; assigning a non-existent profile id returns `400 Unknown LLM profile for role: <role>`.
+- Settings → Agent's stacked panels now have proper spacing between them.
+
+## Export film at the clips' own FPS
+
+Film export no longer forces everything to 30 fps.
+
+- Each scene clip is probed for its real frame rate; the export targets the **majority fps across clips** (e.g. 24 fps clips export at 24 fps).
+- Ties resolve to the lower rate; if no rate can be read, the old default (30) applies.
+- Mixed-rate projects are conformed to the majority rate — the 0.5s crossfade chain needs one common timebase.
+- The export progress message now reports the rate: **"Exporting film (24 fps)…"**.
+- Everything else in the pipeline is unchanged: 1080p normalize → 0.5s crossfades → loudness normalize.
+
+## Housekeeping
+
+- Added `.gitignore` files inside `calliope-backend/` and `calliope-web/` (venv, caches, SQLite data, node_modules, build output) so each sub-folder is self-protecting in addition to the repo-root rules.
+
+## For developers
+
+- `LLMClient` accepts optional `base_url` / `model` / `api_key` overrides and gains `LLMClient.for_role(role)`; unknown roles and dangling profile ids fall back to the Active LLM.
+- New config knob: `agent_llm_assignments` (role → profile id or null), exposed via `GET/POST /api/settings`.
+- `POST /api/settings` accepts `agent_llm_assignments` with server-side validation.
+- Export: `probe()` now returns `fps` (from ffprobe `r_frame_rate`), `parse_rate()` parses rational rates like `24000/1001`, `target_fps()` votes the conform rate, and `build_ffmpeg_cmd(..., fps=...)` takes an optional override.
+- Full backend suite: **248 passed**.

--- a/docs/changelogs/README.md
+++ b/docs/changelogs/README.md
@@ -2,4 +2,6 @@
 
 Dated notes for GitHub releases. Newest first.
 
-- [2026-08-23](./2026-08-23.md) — 1.2.1 (tabbed video refs, HITL, item attach) over 1.2.0
+- [2026-08-29](./2026-08-29.md) — Model per agent + clip-native export fps
+- [2026-08-24](./2026-08-24.md) — Agent + Assets Management (1.2.1)
+- [2026-08-23](./2026-08-23.md) — 1.2.0 / 1.2.1 video, H3, picker, release notes


### PR DESCRIPTION
## Summary

Two features, built task-by-task with per-task commits and a full-suite green at the end (248 passed):

### 1. Model per agent (Settings → Agent)

- New "Model per agent" panel above System Prompt: assign any saved LLM profile to Main agent / Planner / Story / Script / Assets / Video agent. Blank = Active LLM (default, so existing setups are unchanged).
- Config: `agent_llm_assignments` (role → profile id) in `calliope_config.json`, persisted and exposed via `GET/POST /api/settings`; assignments prune automatically when their profile is deleted; `POST` validates and returns 400 for unknown profile ids.
- `LLMClient` gains optional overrides + `LLMClient.for_role(role)`; all harness call sites (main loop, planner, swarm synthesis, sub-agents, H3 rewrite) resolve their role at construction.
- Panel spacing fix for stacked sections on the Agent tab.

### 2. Export film at the clips' own FPS

- Export no longer hardcodes 30 fps: `probe()` reads each clip's `r_frame_rate`, `target_fps()` votes the majority rate (tie → lower; none → 30), and the ffmpeg graph conforms to it. 24 fps clips export at 24 fps.
- Progress message reports the rate: "Exporting film (24 fps)…".
- Crossfade/loudness pipeline untouched.

### Housekeeping

- `.gitignore` added inside `calliope-backend/` and `calliope-web/`; root list drops obsolete electron entries.
- Docs: changelog `2026-08-29`, changelog index, README (multi-LLM first-run, Agent settings section, export fps wording).

## Test plan

- [x] Full backend suite: 248 passed
- [x] `svelte-check`: 0 errors / 0 warnings
- [x] New tests: role resolution/fallback/prune, router validation, `for_role`, `parse_rate`/`target_fps`, fps in `build_ffmpeg_cmd`
- [ ] Manual: Settings → Agent pickers save/reload; export a 24 fps project and confirm "Exporting film (24 fps)…"
