### PR TITLE
chore: bump @sveltejs/kit to 2.70.3 (1.3.1) — defuse npm audit fix --force breakage

### DIFF
--- a/calliope-backend/pyproject.toml
+++ b/calliope-backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "calliope"
-version = "1.3.0"
+version = "1.3.1"
 description = "Local-first AI story-to-video studio"
 requires-python = ">=3.11"
 dependencies = [

--- a/calliope-web/package-lock.json
+++ b/calliope-web/package-lock.json
@@ -1,18 +1,18 @@
 {
 	"name": "calliope-web",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "calliope-web",
-			"version": "1.3.0",
+			"version": "1.3.1",
 			"dependencies": {
 				"@tanstack/svelte-query": "^5.66.0"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-static": "^3.0.8",
-				"@sveltejs/kit": "^2.20.0",
+				"@sveltejs/kit": "^2.70.3",
 				"@sveltejs/vite-plugin-svelte": "^5.0.0",
 				"@types/node": "^22.13.0",
 				"autoprefixer": "^10.4.20",
@@ -1199,9 +1199,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.70.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.1.tgz",
-			"integrity": "sha512-nY9SPHGOZro3doud9vZXDBwl9tCZIouuJztjgSHs6PAIrv9M/z5O7eOhPV5xU7CgVHA976Jwu3BA1hIFvXztkA==",
+			"version": "2.70.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.3.tgz",
+			"integrity": "sha512-UDvEYuZqAMbfB/oXIoqKvbKcb7YczK5zYrzmsGV1zRJk03jntwp8dXiYoIJotxAndsKvcPFtx9H1GRSKFdSHgg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1544,9 +1544,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2481,9 +2481,9 @@
 			}
 		},
 		"node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2710,9 +2710,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"dev": true,
 			"funding": [
 				{
@@ -2906,9 +2906,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.22",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-			"integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2926,7 +2926,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.16",
+				"nanoid": "^3.3.17",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},

--- a/calliope-web/package.json
+++ b/calliope-web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "calliope-web",
-	"version": "1.3.0",
+	"version": "1.3.1",
   "private": true,
   "scripts": {
     "dev": "vite dev",
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.8",
-    "@sveltejs/kit": "^2.20.0",
+		"@sveltejs/kit": "^2.70.3",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@types/node": "^22.13.0",
     "autoprefixer": "^10.4.20",

--- a/docs/changelogs/2026-08-31-patch.md
+++ b/docs/changelogs/2026-08-31-patch.md
@@ -1,0 +1,23 @@
+# 2026-08-31 — Calliope 1.3.1 (patch)
+
+Dependency hygiene fix prompted by [#38](https://github.com/benjiyaya/Calliope/issues/38).
+
+## What changed
+
+- `@sveltejs/kit` bumped `2.20.x` → `^2.70.3`. The older range was flagged by `npm audit` with several high-severity advisories (CSRF protection, dev-mode 404 XSS, handle-hook DoS, unescaped error messages), which pushed users toward `npm audit fix --force` — a command that downgrades kit to a 2021 pre-release (`0.0.30`) and wrecks the install (missing adapter, `svelte.config.js` load failure).
+- Safe non-breaking audit fixes applied (`brace-expansion`, `js-yaml`, `nanoid`, `postcss` transitives). Remaining findings are 3 low-severity transitives only resolvable via SemVer-major downgrades — do **not** run `npm audit fix --force`.
+- Version bumped to 1.3.1 (web + backend). No feature changes.
+
+## For anyone who hit the broken-install state (#38)
+
+Your repo files are fine — the committed `package.json` / `package-lock.json` / `tsconfig.json` are correct, and `.svelte-kit/` is generated output that appears after the first sync. Recover with:
+
+```powershell
+cd calliope-web
+git checkout -- package.json package-lock.json
+Remove-Item -Recurse -Force node_modules
+npm ci
+npm run dev
+```
+
+The `Cannot find base config file "./.svelte-kit/tsconfig.json"` line alone is a harmless first-run warning; the real error was `config.kit.adapter should be an object with an "adapt" method`, caused by `--force` downgrading SvelteKit.

--- a/docs/changelogs/README.md
+++ b/docs/changelogs/README.md
@@ -2,6 +2,7 @@
 
 Dated notes for GitHub releases. Newest first.
 
+- [2026-08-31 patch](./2026-08-31-patch.md) — SvelteKit security bump so `npm audit fix --force` is never needed (1.3.1)
 - [2026-08-31](./2026-08-31.md) — Prompt review gate, ComfyUI error surfacing, saved scene setups (1.3.0)
 - [2026-08-29](./2026-08-29.md) — Model per agent + clip-native export fps + video-extend continue (1.2.3)
 - [2026-08-24](./2026-08-24.md) — Agent + Assets Management (1.2.1)


### PR DESCRIPTION
## Summary

Prompted by #38. The committed `@sveltejs/kit` 2.20.x range carried high-severity `npm audit` advisories (CSRF protection, dev-mode 404 XSS, handle-hook DoS, unescaped error messages), and users hitting the audit output were pushed toward `npm audit fix --force` — which downgrades kit to a 2021 pre-release (`0.0.30`) and breaks the install (the exact failure mode reported in #38: `config.kit.adapter should be an object with an "adapt" method`).

- `@sveltejs/kit` → `^2.70.3` (within-major, fixes all the high advisories and transitively bumps `cookie`)
- Safe non-breaking audit fixes applied (`brace-expansion`, `js-yaml`, `nanoid`, `postcss` transitives)
- Remaining audit output: 3 low-severity transitives, only resolvable via SemVer-major downgrades — the README/changelog now warn against `--force`
- Version → 1.3.1; changelog entry includes recovery steps for users whose installs are already broken

## Test plan

- [x] `svelte-kit sync` + `svelte-check`: 0 errors, 0 warnings
- [x] `npm run build` (adapter-static production build): success
- [x] `npm ls @sveltejs/kit` resolves 2.70.3, deduped with adapter-static 3.0.10
- [ ] Manual: `npm ci && npm run dev` from a clean clone starts without the #38 error
