### PR TITLE
LLM client: per-call extra_body hook + h3_rewrite_extra_body setting (thinking off for the H3 rewrite: 158 s → 27 s)

### DIFF
--- a/calliope-backend/src/calliope/agent/llm.py
+++ b/calliope-backend/src/calliope/agent/llm.py
@@ -16,6 +16,23 @@ logger = logging.getLogger("calliope.llm")
 _STREAM_UNSUPPORTED_STATUS = frozenset({400, 404, 405, 501})
 
 
+_PROTECTED_PAYLOAD_KEYS = frozenset({"model", "messages", "stream"})
+
+
+def _merge_extra_body(payload: dict[str, Any], extra_body: dict[str, Any] | None) -> None:
+    """Merge caller-supplied OpenAI-compatible request fields into a payload.
+
+    Lets one call site pass server-specific knobs (e.g. Qwen3's
+    ``chat_template_kwargs: {"enable_thinking": false}`` on oMLX / vLLM / SGLang)
+    without the client knowing about them. The identity of the request —
+    model, messages, stream — cannot be overridden.
+    """
+    for key, value in (extra_body or {}).items():
+        if key in _PROTECTED_PAYLOAD_KEYS:
+            continue
+        payload[key] = value
+
+
 class LLMClient:
     def __init__(
         self,
@@ -57,12 +74,16 @@ class LLMClient:
         messages: list[dict[str, str]],
         temperature: float = 0.7,
         response_format: dict[str, str] | None = None,
+        extra_body: dict[str, Any] | None = None,
     ) -> str:
         try:
             parts: list[str] = []
             reasoning_chars = 0
             async for ev in self.chat_stream(
-                messages, temperature=temperature, response_format=response_format
+                messages,
+                temperature=temperature,
+                response_format=response_format,
+                extra_body=extra_body,
             ):
                 if ev["type"] == "delta":
                     parts.append(ev["content"])
@@ -77,7 +98,9 @@ class LLMClient:
                 "Streaming unavailable (HTTP %s); falling back to blocking call",
                 exc.response.status_code,
             )
-            return await self._chat_blocking(messages, temperature, response_format)
+            return await self._chat_blocking(
+                messages, temperature, response_format, extra_body=extra_body
+            )
         content = "".join(parts).strip()
         if not content:
             # Thinking models can burn the whole completion in reasoning and
@@ -94,6 +117,7 @@ class LLMClient:
         messages: list[dict[str, str]],
         temperature: float = 0.7,
         response_format: dict[str, str] | None = None,
+        extra_body: dict[str, Any] | None = None,
     ) -> str:
         payload: dict[str, Any] = {
             "model": self.model,
@@ -102,6 +126,7 @@ class LLMClient:
         }
         if response_format:
             payload["response_format"] = response_format
+        _merge_extra_body(payload, extra_body)
 
         url = f"{self.base_url}/chat/completions"
         logger.info("LLM request to %s with model %s", url, self.model)
@@ -205,6 +230,7 @@ class LLMClient:
         tools: list[dict[str, Any]] | None = None,
         tool_choice: str | dict[str, Any] | None = None,
         response_format: dict[str, str] | None = None,
+        extra_body: dict[str, Any] | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
         """Streaming completion. Yields event dicts:
 
@@ -231,6 +257,7 @@ class LLMClient:
                 payload["tool_choice"] = tool_choice
         if response_format:
             payload["response_format"] = response_format
+        _merge_extra_body(payload, extra_body)
         url = f"{self.base_url}/chat/completions"
         logger.info("LLM stream request to %s with model %s", url, self.model)
         tool_acc: dict[int, dict[str, Any]] = {}

--- a/calliope-backend/src/calliope/agent/video_agent.py
+++ b/calliope-backend/src/calliope/agent/video_agent.py
@@ -81,7 +81,9 @@ async def _h3_rewrite(
     client = LLMClient.for_role("video", timeout=timeout)
     try:
         return await client.chat(
-            build_minimax_h3_ref_messages(scene, subjects), temperature=0.4
+            build_minimax_h3_ref_messages(scene, subjects),
+            temperature=0.4,
+            extra_body=settings.h3_rewrite_extra_body or None,
         )
     except Exception as exc:
         logger.warning("MiniMax H3 prompt rewrite failed (%s); using fallback template", exc)

--- a/calliope-backend/src/calliope/config.py
+++ b/calliope-backend/src/calliope/config.py
@@ -125,6 +125,14 @@ class Settings(BaseSettings):
     queue_max_retries: int = 2
     agent_max_steps: int = 24
     agent_hardening_prompt: str = DEFAULT_AGENT_HARDENING_PROMPT
+    # Extra OpenAI-compatible request fields merged into the MiniMax H3 prompt
+    # rewrite call only (the `minimax_h3_ref` profile). The rewrite is a
+    # formatting task: on a thinking model it can burn 10k+ reasoning tokens per
+    # scene, so e.g. {"chat_template_kwargs": {"enable_thinking": false}} (oMLX,
+    # vLLM, SGLang for Qwen3) makes previews seconds instead of minutes. Empty
+    # by default — never sent unless set, since strict servers reject unknown
+    # fields.
+    h3_rewrite_extra_body: dict[str, Any] = Field(default_factory=dict)
     dry_run: bool = False  # off by default — real ComfyUI jobs
 
     @property
@@ -313,6 +321,7 @@ class Settings(BaseSettings):
             "queue_max_retries": self.queue_max_retries,
             "agent_max_steps": self.agent_max_steps,
             "agent_hardening_prompt": self.agent_hardening_prompt,
+            "h3_rewrite_extra_body": dict(self.h3_rewrite_extra_body or {}),
             "dry_run": bool(self.dry_run),
         }
 
@@ -395,6 +404,7 @@ class Settings(BaseSettings):
             "queue_max_retries": self.queue_max_retries,
             "agent_max_steps": self.agent_max_steps,
             "agent_hardening_prompt": self.agent_hardening_prompt,
+            "h3_rewrite_extra_body": dict(self.h3_rewrite_extra_body or {}),
             "dry_run": bool(self.dry_run),
         }
         CONFIG_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/calliope-backend/src/calliope/routers/settings.py
+++ b/calliope-backend/src/calliope/routers/settings.py
@@ -36,6 +36,7 @@ class SettingsUpdate(BaseModel):
     queue_max_retries: int | None = Field(None, ge=0, le=10)
     agent_max_steps: int | None = Field(None, ge=1, le=100)
     agent_hardening_prompt: str | None = Field(None, max_length=20000)
+    h3_rewrite_extra_body: dict[str, Any] | None = None
     dry_run: bool | None = None
 
 

--- a/calliope-backend/tests/test_h3_rewrite_extra_body.py
+++ b/calliope-backend/tests/test_h3_rewrite_extra_body.py
@@ -51,7 +51,9 @@ async def test_no_extra_body_sends_nothing_extra(monkeypatch):
 
 
 def test_setting_roundtrip(client):
-    assert client.get("/api/settings").json()["h3_rewrite_extra_body"] == {}
+    # The fixture serves the live settings object, so the starting value is
+    # whatever the operator has set — restore it at the end.
+    original = client.get("/api/settings").json()["h3_rewrite_extra_body"]
     r = client.post(
         "/api/settings",
         json={"h3_rewrite_extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
@@ -63,3 +65,5 @@ def test_setting_roundtrip(client):
     r = client.post("/api/settings", json={"h3_rewrite_extra_body": {}})
     assert r.status_code == 200
     assert client.get("/api/settings").json()["h3_rewrite_extra_body"] == {}
+    client.post("/api/settings", json={"h3_rewrite_extra_body": original})
+    assert client.get("/api/settings").json()["h3_rewrite_extra_body"] == original

--- a/calliope-backend/tests/test_h3_rewrite_extra_body.py
+++ b/calliope-backend/tests/test_h3_rewrite_extra_body.py
@@ -1,0 +1,65 @@
+"""The H3 rewrite's per-call request hook: `h3_rewrite_extra_body`.
+
+The `minimax_h3_ref` profile rewrite is a formatting task; on a thinking model
+it can spend 10k+ reasoning tokens per scene. The setting lets an operator
+merge server-specific fields into that ONE call (e.g. Qwen3's
+`chat_template_kwargs.enable_thinking=false`) without touching story/script
+calls. Nothing is sent unless the setting is non-empty.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from calliope.agent.llm import LLMClient
+
+
+class _CaptureRouter:
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    async def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(json.loads(request.content.decode()))
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+
+async def test_extra_body_is_merged_into_the_request(monkeypatch):
+    router = _CaptureRouter()
+    client = LLMClient()
+    monkeypatch.setattr(client, "client", httpx.AsyncClient(transport=httpx.MockTransport(router)))
+
+    text = await client._chat_blocking(
+        [{"role": "user", "content": "hi"}],
+        extra_body={"chat_template_kwargs": {"enable_thinking": False}, "model": "hijack"},
+    )
+
+    assert text == "ok"
+    body = router.requests[0]
+    assert body["chat_template_kwargs"] == {"enable_thinking": False}
+    assert body["model"] != "hijack"  # request identity cannot be overridden
+
+
+async def test_no_extra_body_sends_nothing_extra(monkeypatch):
+    router = _CaptureRouter()
+    client = LLMClient()
+    monkeypatch.setattr(client, "client", httpx.AsyncClient(transport=httpx.MockTransport(router)))
+
+    await client._chat_blocking([{"role": "user", "content": "hi"}])
+
+    assert set(router.requests[0]) == {"model", "messages", "temperature"}
+
+
+def test_setting_roundtrip(client):
+    assert client.get("/api/settings").json()["h3_rewrite_extra_body"] == {}
+    r = client.post(
+        "/api/settings",
+        json={"h3_rewrite_extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+    )
+    assert r.status_code == 200
+    assert client.get("/api/settings").json()["h3_rewrite_extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": False}
+    }
+    r = client.post("/api/settings", json={"h3_rewrite_extra_body": {}})
+    assert r.status_code == 200
+    assert client.get("/api/settings").json()["h3_rewrite_extra_body"] == {}


### PR DESCRIPTION
## What

A small, generic hook: `LLMClient.chat` / `chat_stream` / `_chat_blocking` accept an optional `extra_body: dict` that is merged into the OpenAI-compatible request payload (`model`, `messages` and `stream` cannot be overridden). One caller uses it today: the `minimax_h3_ref` prompt rewrite in `video_agent._h3_rewrite`, driven by a new setting `h3_rewrite_extra_body` (default `{}` — nothing is sent unless set), exposed on `GET/POST /api/settings` and persisted in the config file.

## Why

The H3 six-section rewrite is a *formatting* task. On a thinking model it can spend far more on reasoning than on the answer, and because the client streams, the 30 s preview / 120 s enqueue timeouts bound the gap between chunks, not the total — so nothing ever falls back or warns, the preview just takes minutes.

Measured on a Qwen3.8-27B served by oMLX (one scene, one wired subject, one dialogue line; server-side token/time log):

| H3 rewrite | tokens | time |
|---|---|---|
| thinking on, no budget | 13,084 | 611 s |
| thinking on, 4,096-token server-side budget | 4,761 | 158 s |
| `h3_rewrite_extra_body: {"chat_template_kwargs": {"enable_thinking": false}}` | 723 | **27 s** |

Output shape was equal or better with thinking off (2 timed shots, camera grammar, dialogue verbatim). Story and script generation are untouched — they keep whatever thinking the model does by default.

`chat_template_kwargs.enable_thinking` is honoured by oMLX, vLLM and SGLang for Qwen3; other servers get whatever the operator puts in the dict, and strict servers get nothing because the default is empty.

## Changes

- `agent/llm.py`: `_merge_extra_body()` + `extra_body` on the three call paths.
- `agent/video_agent.py`: pass `settings.h3_rewrite_extra_body or None` on the H3 rewrite.
- `config.py`, `routers/settings.py`: the setting, its public/persisted dict entries, `SettingsUpdate` field.
- `tests/test_h3_rewrite_extra_body.py`: merge into the payload (and that `model` can't be hijacked), nothing extra sent by default, settings API round-trip.

Related test suites pass (llm_json, llm_profiles, h3_profile, agent_llm_roles). The one ruff `E501` in `llm.py` is pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
