### PR TITLE
Health/OpenAPI version: read package metadata instead of a hard-coded string

### DIFF
--- a/calliope-backend/src/calliope/main.py
+++ b/calliope-backend/src/calliope/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import sys
 from contextlib import asynccontextmanager
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
@@ -28,6 +29,11 @@ from calliope.routers import (
     story,
     workflows,
 )
+
+try:
+    __version__ = _pkg_version("calliope")
+except PackageNotFoundError:  # running from a source tree that was never installed
+    __version__ = "0.0.0+src"
 
 logging.basicConfig(
     level=logging.INFO,
@@ -111,7 +117,7 @@ async def lifespan(app: FastAPI):
 
 
 def create_app(static_dir: Path | None = None) -> FastAPI:
-    app = FastAPI(title="Calliope", version="1.4.0", lifespan=lifespan)
+    app = FastAPI(title="Calliope", version=__version__, lifespan=lifespan)
 
     app.add_middleware(
         CORSMiddleware,
@@ -135,7 +141,7 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
 
     @app.get("/api/health")
     async def health() -> dict:
-        return {"status": "ok", "version": "1.4.0", "dry_run": settings.dry_run}
+        return {"status": "ok", "version": __version__, "dry_run": settings.dry_run}
 
     # Catch unknown /api/* before StaticFiles — otherwise POST falls through and
     # returns a confusing 405 Method Not Allowed from the file server.

--- a/calliope-backend/tests/test_projects.py
+++ b/calliope-backend/tests/test_projects.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import tempfile
 from pathlib import Path
 
@@ -41,6 +42,15 @@ def test_health(client):
     r = client.get("/api/health")
     assert r.status_code == 200
     assert r.json()["status"] == "ok"
+
+
+def test_health_version_matches_package_metadata(client):
+    from calliope.main import __version__
+
+    assert client.get("/api/health").json()["version"] == __version__
+    # A literal here would recreate the bug this guards against: the string must
+    # come from the installed package metadata (pyproject's version), not main.py.
+    assert __version__ == importlib.metadata.version("calliope")
 
 
 def test_create_and_list_project(client):


### PR DESCRIPTION
## Problem

`main.py` carries the version as two literals — `FastAPI(title="Calliope", version="…")` and the `/api/health` payload. They have drifted from `pyproject.toml` twice:

- v1.3.2 shipped with `main.py` still saying `1.2.1`
- v1.4.1 (`f4424a5`) bumps `pyproject.toml` and `package.json` to 1.4.1 but `/api/health` still reports `1.4.0`

A client that checks `/api/health` after `git pull` + restart cannot tell whether the restart took.

## Fix

Derive `__version__` once from `importlib.metadata.version("calliope")` — the value `pyproject.toml` already owns — and use it in both places. A source tree that was never `pip install -e`'d falls back to `0.0.0+src` instead of failing at import.

`test_health` gains a sibling that asserts the served version equals the package metadata, so a future literal fails the suite.

## Verified

- `tests/test_projects.py -k health`: 2 passed
- On an installed 1.4.1 tree: `from calliope.main import __version__` → `1.4.1`; the `1.4.0` literal is gone.

No behaviour change beyond the reported string. Touches `calliope-backend/src/calliope/main.py` and `calliope-backend/tests/test_projects.py` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
