### PR TITLE
Event log: append_event returns the row id, not the per-session seq — card clicks never record an approval

### DIFF
--- a/calliope-backend/src/calliope/agent/harness/log.py
+++ b/calliope-backend/src/calliope/agent/harness/log.py
@@ -112,7 +112,14 @@ def append_event(session_id: int, event_type: str, data: dict[str, Any]) -> Sess
             """,
             (session_id, session_id, event_type, json.dumps(data, ensure_ascii=False, default=str)),
         )
-        seq = cur.lastrowid
+        # cur.lastrowid is the table-wide row id, NOT the per-session seq the
+        # INSERT just allocated; read the seq back. Returning the row id made
+        # ask_user hand the card a question_seq that latest_open_question()
+        # (which compares per-session seq) could never match, so a card click
+        # never wrote question/answered once more than one session existed.
+        seq = conn.execute(
+            "SELECT seq FROM agent_events WHERE id = ?", (cur.lastrowid,)
+        ).fetchone()["seq"]
         conn.execute(
             "UPDATE agent_sessions SET updated_at = CURRENT_TIMESTAMP WHERE id = ?",
             (session_id,),

--- a/calliope-backend/tests/test_agent_interaction.py
+++ b/calliope-backend/tests/test_agent_interaction.py
@@ -250,3 +250,54 @@ def test_ask_user_logs_tool_result_before_turn_end(client, session):
     assert tr.data["result"]["question"] == "Regenerate the script?"
     end = events[end_idx]
     assert end.data["status"] == "awaiting_input", end.data
+
+
+def test_append_event_returns_per_session_seq(client, session):
+    """append_event must return the per-session seq it allocated, not the
+    table-wide row id. Once any other session has events the two diverge, and
+    ask_user's question_seq (taken from the returned event) must still match
+    what read_events / latest_open_question report for the same row."""
+    other = client.post("/api/agent/sessions", json={}).json()
+    for i in range(3):
+        session_log.append_event(other["id"], "assistant/message", {"content": f"noise {i}"})
+
+    ev = session_log.append_event(
+        session["id"],
+        session_log.QUESTION_ASKED,
+        {"question": "q?", "options": ["a", "b"], "scope": "info"},
+    )
+    events = session_log.read_events(session["id"])
+    stored = [e for e in events if e.type == session_log.QUESTION_ASKED]
+    assert len(stored) == 1
+    assert ev.seq == stored[0].seq
+    assert interaction.latest_open_question(session["id"])["seq"] == ev.seq
+
+
+def test_card_answer_matches_question_when_other_sessions_exist(client, session):
+    """The card click flow end to end with a second, busier session in the
+    table: question_seq handed to the card must still record question/answered."""
+    import asyncio
+
+    other = client.post("/api/agent/sessions", json={}).json()
+    for i in range(5):
+        session_log.append_event(other["id"], "assistant/message", {"content": f"noise {i}"})
+
+    ctx = ToolContext(session_id=session["id"], project_id=None)
+    asked = asyncio.run(
+        execute_tool(
+            ctx,
+            "ask_user",
+            {"question": "Render now?", "options": ["Yes", "No"], "scope": "render"},
+        )
+    )
+    resp = client.post(
+        f"/api/agent/sessions/{session['id']}/messages",
+        json={"content": "Yes", "answer_to": asked["question_seq"]},
+    )
+    assert resp.status_code == 200, resp.text
+    events = session_log.read_events(session["id"])
+    answered = [e for e in events if e.type == session_log.QUESTION_ANSWERED]
+    assert len(answered) == 1
+    assert answered[0].data["question_seq"] == asked["question_seq"]
+    assert policy.has_structured_approval(ctx, "render") is True
+


### PR DESCRIPTION
## Problem

`agent/harness/log.py::append_event` returns `cur.lastrowid` as the event's `seq`. That is the table-wide **row id**, not the **per-session seq** the INSERT allocates (`COALESCE(MAX(seq) WHERE session_id = ?) + 1`). `read_events` returns the real `seq` column.

The two only coincide while a single session exists — which is exactly the situation the test suite is in, so nothing caught it. On a real install:

1. `ask_user` returns `question_seq = ev.seq` (the row id, e.g. **5565**) and the card sends it back as `answer_to`.
2. `runner.start_turn` compares it with `latest_open_question()["seq"]` — the per-session seq (e.g. **109**) — never equal.
3. No `question/answered` is written, so `has_structured_approval()` is always False: a card click is never a structured approval. Render / replace approvals from a card only work by the prose fallback (`_answer_is_affirmative` on the option's first word), which silently fails for any affirmative option that does not start with a yes-word.

Observed on a 1.4.1 host: session 157, `question/asked` row `id 5565 / seq 109`, click posted with `answer_to 5565`, `question/answered` count 0.

## Fix

Read the allocated `seq` back for the inserted row (`SELECT seq FROM agent_events WHERE id = ?`) and return that. One statement, same transaction.

## Tests

Two regression tests in `tests/test_agent_interaction.py`; both create a second session with events first so row id ≠ seq:

- `test_append_event_returns_per_session_seq` — the returned seq equals what `read_events` / `latest_open_question` report.
- `test_card_answer_matches_question_when_other_sessions_exist` — the full card flow (`ask_user` → `POST …/messages` with `answer_to`) writes `question/answered` and grants the render approval.

Both fail on `main` and pass with the fix. `ruff` adds no new findings over the existing ones in these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
