### PR TITLE
Agent chat: live agent.message echo lacks parsed tool_result — ask_user card only renders after a reload

### DIFF
--- a/calliope-backend/src/calliope/agent/harness/runner.py
+++ b/calliope-backend/src/calliope/agent/harness/runner.py
@@ -117,7 +117,16 @@ class AgentRunner:
             row = conn.execute(
                 "SELECT * FROM agent_messages WHERE id = ?", (cur.lastrowid,)
             ).fetchone()
-            return row_to_dict(row)
+            out = row_to_dict(row)
+            # The SSE echo of this row is what a connected client appends to
+            # its chat without a refetch. GET /sessions/{id} hands clients
+            # parsed `tool_args` / `tool_result`; the raw row only has the
+            # *_json strings, so a live ask_user row carried no `tool_result`
+            # and the question card only appeared after a reload. Ship the
+            # parsed values too (the *_json keys stay for compatibility).
+            out["tool_args"] = tool_args if tool_args else None
+            out["tool_result"] = tool_result
+            return out
         finally:
             conn.close()
 

--- a/calliope-backend/tests/test_agent_interaction.py
+++ b/calliope-backend/tests/test_agent_interaction.py
@@ -250,3 +250,49 @@ def test_ask_user_logs_tool_result_before_turn_end(client, session):
     assert tr.data["result"]["question"] == "Regenerate the script?"
     end = events[end_idx]
     assert end.data["status"] == "awaiting_input", end.data
+
+
+
+def test_live_message_echo_carries_parsed_tool_result(client, session, monkeypatch):
+    """The agent.message SSE echo for an ask_user tool row must carry the
+    parsed `tool_result` (question/options/scope) the way GET /sessions/{id}
+    does — AgentChat derives the question card from it, so a raw row with only
+    tool_result_json rendered no card until the page was reloaded."""
+    import asyncio
+
+    from calliope.agent.harness.runner import AgentRunner
+    from calliope.events.bus import event_bus
+
+    published: list[tuple[str, dict]] = []
+
+    async def capture(event_type, data):
+        published.append((event_type, data))
+
+    monkeypatch.setattr(event_bus, "publish", capture)
+    sink = AgentRunner()._make_message_sink(session["id"])
+    result = {
+        "ok": True,
+        "awaiting_user_input": True,
+        "question_seq": 7,
+        "question": "Render now?",
+        "options": ["Yes, render", "No, not yet"],
+        "scope": "render",
+    }
+    asyncio.run(
+        sink(
+            {
+                "role": "tool",
+                "tool_name": "ask_user",
+                "tool_args": {"question": "Render now?"},
+                "tool_result": result,
+            }
+        )
+    )
+
+    echoes = [d["message"] for t, d in published if t == "agent.message"]
+    assert len(echoes) == 1
+    msg = echoes[0]
+    assert msg["tool_name"] == "ask_user"
+    assert msg["tool_result"] == result
+    assert msg["tool_args"] == {"question": "Render now?"}
+    assert isinstance(msg["tool_result_json"], str)  # raw keys still present


### PR DESCRIPTION
## Problem

The `agent.message` SSE echo for a tool row is the raw `agent_messages` row (`row_to_dict`): it carries `tool_args_json` / `tool_result_json` **strings** and no `tool_args` / `tool_result`. `GET /api/agent/sessions/{id}` hands clients the **parsed** `tool_result` (`_rows_to_messages`), and that is what `AgentChat.svelte` derives the `ask_user` question card from (`m.tool_result.options`). The canvas page's `appendMessage` pushes the SSE row as-is.

Result on a connected client: the `ask_user done` tool row appears live, the turn ends (1.4.1's `awaiting_input` fix works), but **no card is rendered until the page is reloaded** — the symptom the 1.4.1 changelog describes. Observed on a 1.4.1 host: `document.querySelectorAll('.question-card').length` = 0 after 25 min connected, 1 immediately after a reload.

## Fix

`AgentRunner._persist_message` returns the row plus the parsed `tool_args` and `tool_result` it just stored (the `*_json` keys stay, nothing in `calliope-web` reads them). Every `agent.message` echo now has the same shape as the GET rows, so the card derives live with no frontend change.

## Test

`test_live_message_echo_carries_parsed_tool_result` (`tests/test_agent_interaction.py`): runs the runner's message sink for an `ask_user` tool row with `event_bus.publish` captured and asserts the echoed message carries the parsed `tool_result` and `tool_args` alongside the raw string. Fails on `main`, passes with the fix. `ruff` adds no new findings.

Independent of #48 (event seq) — both are needed for a card click to work end to end: this one shows the card live, that one makes the click count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
